### PR TITLE
Jersey style updates

### DIFF
--- a/app/assets/stylesheets/petitions/_details.scss
+++ b/app/assets/stylesheets/petitions/_details.scss
@@ -15,7 +15,7 @@ details {
 
     @include media(desktop){
       &:hover {
-        color: $link-hover-colour;
+        color: $petitions-link-hover-colour;
       }
     }
 

--- a/app/assets/stylesheets/petitions/admin/views/_hub.scss
+++ b/app/assets/stylesheets/petitions/admin/views/_hub.scss
@@ -15,7 +15,7 @@
       @include box-sizing(border-box);
       width: 100%;
       height: 200px;
-      background-color: $states-assembly-red;
+      background-color: $house-of-commons-green;
       padding: $gutter-half;
       color: $white;
       @include bold-27;
@@ -40,7 +40,7 @@
     margin-right: $gutter-half;
 
     .queue-stable {
-      background-color: $states-assembly-red;
+      background-color: $house-of-commons-green;
     }
 
     .queue-caution {


### PR DESCRIPTION
A couple of colour changes including revert to green for admin panels to keep the "traffic light" moderation queue colour scheme: 


![screen shot 2018-05-22 at 11 23 49](https://user-images.githubusercontent.com/1370570/40357228-65f85f38-5db3-11e8-886a-878a14744687.png)
