### PR TITLE
Rename UK citizenship

### DIFF
--- a/app/assets/stylesheets/petitions/views/_sign.scss
+++ b/app/assets/stylesheets/petitions/views/_sign.scss
@@ -30,6 +30,6 @@
   }
 }
 
-.uk-citizen p {
+.jersey-resident p {
   margin-bottom: 0;
 }

--- a/app/controllers/signatures_controller.rb
+++ b/app/controllers/signatures_controller.rb
@@ -187,6 +187,6 @@ class SignaturesController < ApplicationController
   end
 
   def signature_attributes
-    %i[name email email_confirmation postcode uk_citizenship notify_by_email]
+    %i[name email email_confirmation postcode jersey_resident notify_by_email]
   end
 end

--- a/app/models/petition_creator.rb
+++ b/app/models/petition_creator.rb
@@ -8,7 +8,7 @@ class PetitionCreator
   STAGES = %w[petition replay_petition creator replay_email]
 
   PETITION_PARAMS  = [:action, :background, :additional_details]
-  SIGNATURE_PARAMS = [:name, :email, :postcode, :uk_citizenship, :notify_by_email]
+  SIGNATURE_PARAMS = [:name, :email, :postcode, :jersey_resident, :notify_by_email]
   PERMITTED_PARAMS = [:q, :stage, :move_back, :move_next, petition_creator: PETITION_PARAMS + SIGNATURE_PARAMS]
 
   attr_reader :params, :errors, :request
@@ -54,7 +54,7 @@ class PetitionCreator
           c.name = name
           c.email = email
           c.postcode = postcode
-          c.uk_citizenship = uk_citizenship
+          c.jersey_resident = jersey_resident
           c.constituency_id = constituency_id
           c.notify_by_email = notify_by_email
           c.ip_address = request.remote_ip
@@ -110,8 +110,8 @@ class PetitionCreator
     PostcodeSanitizer.call(petition_creator_params[:postcode])
   end
 
-  def uk_citizenship
-    petition_creator_params[:uk_citizenship] || "0"
+  def jersey_resident
+    petition_creator_params[:jersey_resident] || "0"
   end
 
   def notify_by_email
@@ -164,7 +164,7 @@ class PetitionCreator
     errors.add(:name, :blank) unless name.present?
     errors.add(:name, :too_long, count: 255) if action.length > 255
     errors.add(:email, :blank) unless email.present?
-    errors.add(:uk_citizenship, :accepted) unless uk_citizenship == "1"
+    errors.add(:jersey_resident, :accepted) unless jersey_resident == "1"
 
     if email.present?
       email_validator.validate(self)

--- a/app/models/signature.rb
+++ b/app/models/signature.rb
@@ -31,7 +31,7 @@ class Signature < ActiveRecord::Base
   validates :name, presence: true, length: { maximum: 255 }
   validates :email, presence: true, email: { allow_blank: true }, on: :create
   validates :postcode, presence: true, postcode: true
-  validates :uk_citizenship, acceptance: true, unless: :persisted?, allow_nil: false
+  validates :jersey_resident, acceptance: true, unless: :persisted?, allow_nil: false
   validates :constituency_id, length: { maximum: 255 }
 
   attr_readonly :sponsor, :creator
@@ -258,7 +258,7 @@ class Signature < ActiveRecord::Base
     end
   end
 
-  attr_accessor :uk_citizenship
+  attr_accessor :jersey_resident
 
   def find_duplicate
     return nil unless petition

--- a/app/views/pages/help.html.erb
+++ b/app/views/pages/help.html.erb
@@ -5,7 +5,7 @@
 <h1 class="page-title">How petitions work</h1>
 
 <ol class="list-number">
-  <li>You create a petition. Only British citizens and UK residents can create or sign a petition.</li>
+  <li>You create a petition. Only Jersey residents aged 16 or over can create or sign a petition.</li>
   <li>You get 5 people to support your petition. We’ll tell you how to do this when you’ve created your petition.</li>
   <li>We check your petition, then publish it. We only reject petitions that don’t meet the standards for petitions.</li>
   <li>The Petitions Committee reviews all petitions we publish. They select petitions of interest to find out more about the issues raised. They have the power to press for action from government or Parliament.</li>

--- a/app/views/petitions/create/_creator_stage.html.erb
+++ b/app/views/petitions/create/_creator_stage.html.erb
@@ -9,14 +9,14 @@
 
 <%= render "petitions/create/error_summary", form: form %>
 
-<%= form_row for: [petition, :uk_citizenship], class: "uk-citizen" do %>
+<%= form_row for: [petition, :jersey_resident], class: "jersey-resident" do %>
   <span class="form-label">
-    Only British citizens or UK residents have the right to create and sign petitions
+    Only Jersey residents aged 16 or over have the right to create and sign petitions
   </span>
-  <%= error_messages_for_field petition, :uk_citizenship %>
+  <%= error_messages_for_field petition, :jersey_resident %>
   <div class="multiple-choice">
-    <%= form.check_box :uk_citizenship, tabindex: increment %>
-    <%= form.label :uk_citizenship, "I am a British citizen or UK resident" %>
+    <%= form.check_box :jersey_resident, tabindex: increment %>
+    <%= form.label :jersey_resident, "I am a Jersey resident and aged 16 or over" %>
   </div>
 <% end %>
 

--- a/app/views/petitions/create/_replay_email_stage.html.erb
+++ b/app/views/petitions/create/_replay_email_stage.html.erb
@@ -5,7 +5,7 @@
 <%= form.hidden_field :additional_details %>
 
 <%= form.hidden_field :name %>
-<%= form.hidden_field :uk_citizenship %>
+<%= form.hidden_field :jersey_resident %>
 <%= form.hidden_field :postcode %>
 <%= form.hidden_field :notify_by_email %>
 

--- a/app/views/signatures/_email_form.html.erb
+++ b/app/views/signatures/_email_form.html.erb
@@ -1,7 +1,7 @@
 <h1 class="page-title">Make sure this is right</h1>
 
 <%= form.hidden_field :name %>
-<%= form.hidden_field :uk_citizenship %>
+<%= form.hidden_field :jersey_resident %>
 <%= form.hidden_field :postcode %>
 <%= form.hidden_field :notify_by_email %>
 

--- a/app/views/signatures/_form.html.erb
+++ b/app/views/signatures/_form.html.erb
@@ -1,11 +1,11 @@
-<%= form_row for: [signature, :uk_citizenship], class: "uk-citizen" do %>
+<%= form_row for: [signature, :jersey_resident], class: "jersey-resident" do %>
   <span class="form-label">
-    Only British citizens or UK residents have the right to sign
+    Only Jersey residents aged 16 or over have the right to sign
   </span>
-  <%= error_messages_for_field signature, :uk_citizenship %>
+  <%= error_messages_for_field signature, :jersey_resident %>
   <div class="multiple-choice">
-    <%= form.check_box :uk_citizenship, tabindex: increment %>
-    <%= form.label :uk_citizenship, "I am a British citizen or UK resident" %>
+    <%= form.check_box :jersey_resident, tabindex: increment %>
+    <%= form.label :jersey_resident, "I am a Jersey resident and aged 16 or over" %>
   </div>
 <% end %>
 

--- a/config/locales/activerecord.en-GB.yml
+++ b/config/locales/activerecord.en-GB.yml
@@ -110,5 +110,5 @@ en-GB:
       postcode:
         blank: "Postcode must be completed"
         invalid: "Postcode not recognised"
-      uk_citizenship:
-        accepted: "You must be a British citizen or normally live in the UK to create or sign petitions"
+      jersey_resident:
+        accepted: "You must be a Jersey resident and aged 16 or over to create or sign petitions"

--- a/features/charlie_creates_a_petition.feature
+++ b/features/charlie_creates_a_petition.feature
@@ -117,7 +117,7 @@ Scenario: Charlie tries to submit an invalid petition
   When I press "Continue"
   Then I should see "Name must be completed"
   And I should see "Email must be completed"
-  And I should see "You must be a British citizen"
+  And I should see "You must be a Jersey resident"
   And I should see "Postcode must be completed"
 
   When I fill in my details

--- a/features/step_definitions/rate_limit_steps.rb
+++ b/features/step_definitions/rate_limit_steps.rb
@@ -15,7 +15,7 @@ Given(/^there is a signature already from this IP address$/) do
     When I go to the new signature page for "Do something!"
     And I fill in "Name" with "Existing Signer"
     And I fill in "Email" with "existing@example.com"
-    And I check "I am a British citizen or UK resident"
+    And I check "I am a Jersey resident and aged 16 or over"
     And I fill in my postcode with "SW14 9RQ"
     And I try to sign
     And I say I am happy with my email address

--- a/features/step_definitions/signature_steps.rb
+++ b/features/step_definitions/signature_steps.rb
@@ -36,9 +36,9 @@ Then /^I should have signed the petition$/ do
   should_be_signature_count_of(2)
 end
 
-When /^I fill in my non\-UK details$/ do
+When /^I fill in my non\-Jersey details$/ do
   step "I fill in my details"
-  uncheck "I am a British citizen or UK resident"
+  uncheck "I am a Jersey resident and aged 16 or over"
 end
 
 When(/^I fill in my details(?: with email "([^"]+)")?$/) do |email_address|
@@ -46,7 +46,7 @@ When(/^I fill in my details(?: with email "([^"]+)")?$/) do |email_address|
   steps %Q(
     When I fill in "Name" with "Womboid Wibbledon"
     And I fill in "Email" with "#{email_address}"
-    And I check "I am a British citizen or UK resident"
+    And I check "I am a Jersey resident and aged 16 or over"
     And I fill in my postcode with "SW14 9RQ"
     And I check "Email me whenever there’s an update about this petition"
   )
@@ -56,7 +56,7 @@ When(/^I fill in my details with postcode "(.*?)"?$/) do |postcode|
   steps %Q(
     When I fill in "Name" with "Womboid Wibbledon"
     And I fill in "Email" with "womboid@wimbledon.com"
-    And I check "I am a British citizen or UK resident"
+    And I check "I am a Jersey resident and aged 16 or over"
     And I fill in my postcode with "#{postcode}"
     And I check "Email me whenever there’s an update about this petition"
   )

--- a/features/step_definitions/sponsor_steps.rb
+++ b/features/step_definitions/sponsor_steps.rb
@@ -19,7 +19,7 @@ When(/^a sponsor supports my petition$/) do
     When I visit the "sponsor this petition" url I was given
     And I fill in "Name" with "Anonymous Sponsor"
     And I fill in "Email" with "#{sponsor_email}"
-    And I check "I am a British citizen or UK resident"
+    And I check "I am a Jersey resident and aged 16 or over"
     And I fill in my postcode with "SW1A 1AA"
     And I try to sign
     And I say I am happy with my email address
@@ -87,7 +87,7 @@ When(/^I fill in my details as a sponsor(?: with email "(.*?)")?$/) do |email_ad
   steps %{
     When I fill in "Name" with "Laura The Sponsor"
     And I fill in "Email" with "#{email_address}"
-    And I check "I am a British citizen or UK resident"
+    And I check "I am a Jersey resident and aged 16 or over"
     And I fill in my postcode with "AB10 1AA"
     And I check "Email me whenever there’s an update about this petition"
   }

--- a/features/suzie_signs_a_petition.feature
+++ b/features/suzie_signs_a_petition.feature
@@ -51,9 +51,9 @@ Feature: Suzie signs a petition
     And I should not see the text "Your constituency is"
     And I should not see the text "Your MP is"
 
-  Scenario: Suzie cannot sign if she is not a UK citizen
+  Scenario: Suzie cannot sign if she is not a Jersey resident
     When I decide to sign the petition
-    And I fill in my non-UK details
+    And I fill in my non-Jersey details
     And I try to sign
     Then I should see an error
 

--- a/lib/tasks/data-generator.rake
+++ b/lib/tasks/data-generator.rake
@@ -34,7 +34,7 @@ namespace :data do
           background: Faker::Lorem.sentence(rand(7..22)).first(200),
           additional_details: Faker::Lorem.paragraph(rand(2..20)).first(500),
           creator: Signature.new({
-            uk_citizenship: '1',
+            jersey_resident: '1',
             name: Faker::Name.name,
             email: Faker::Internet.safe_email,
             state: 'validated',
@@ -47,7 +47,7 @@ namespace :data do
         # Create the sponsor signatures
         5.times do
           petition.sponsors.create!(
-            uk_citizenship: '1',
+            jersey_resident: '1',
             name: Faker::Name.name,
             email: Faker::Internet.safe_email("#{Faker::Lorem.characters(rand(10..40))}-#{rand(1..999999)}"),
             state: 'validated',
@@ -86,7 +86,7 @@ namespace :data do
 
         @signature_count.to_i.times do
           signature = petition.signatures.create!(
-            uk_citizenship: '1',
+            jersey_resident: '1',
             name: Faker::Name.name,
             email: Faker::Internet.safe_email("#{Faker::Lorem.characters(rand(10..40))}-#{rand(1..999999)}"),
             postcode: POSTCODES.sample

--- a/spec/controllers/petitions_controller_spec.rb
+++ b/spec/controllers/petitions_controller_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe PetitionsController, type: :controller do
         background: "Limit temperature rise at two degrees",
         additional_details: "Global warming is upon us",
         name: "John Mcenroe", email: "john@example.com",
-        postcode: "SE3 4LL", uk_citizenship: "1"
+        postcode: "SE3 4LL", jersey_resident: "1"
       }
     end
 
@@ -167,9 +167,9 @@ RSpec.describe PetitionsController, type: :controller do
           expect(response).to be_success
         end
 
-        it "should not create a new petition if UK citizenship is not confirmed" do
+        it "should not create a new petition if Jersey resident is not confirmed" do
           perform_enqueued_jobs do
-            post :create, params: { stage: "replay_email", petition_creator: params.merge(uk_citizenship: "0") }
+            post :create, params: { stage: "replay_email", petition_creator: params.merge(jersey_resident: "0") }
           end
 
           expect(petition).to be_nil
@@ -208,9 +208,9 @@ RSpec.describe PetitionsController, type: :controller do
           expect(assigns[:new_petition].stage).to eq "creator"
         end
 
-        it "has stage of 'creator' if there is an error on uk_citizenship" do
+        it "has stage of 'creator' if there is an error on jersey_resident" do
           perform_enqueued_jobs do
-            post :create, params: { stage: "replay_email", petition_creator: params.merge(uk_citizenship: "0") }
+            post :create, params: { stage: "replay_email", petition_creator: params.merge(jersey_resident: "0") }
           end
 
           expect(assigns[:new_petition].stage).to eq "creator"

--- a/spec/controllers/signatures_controller_spec.rb
+++ b/spec/controllers/signatures_controller_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe SignaturesController, type: :controller do
       {
         name: "Ted Berry",
         email: "ted@example.com",
-        uk_citizenship: "1",
+        jersey_resident: "1",
         postcode: "SW1A 1AA"
       }
     end
@@ -132,7 +132,7 @@ RSpec.describe SignaturesController, type: :controller do
       it "sets the signature's params" do
         expect(assigns[:signature].name).to eq("Ted Berry")
         expect(assigns[:signature].email).to eq("ted@example.com")
-        expect(assigns[:signature].uk_citizenship).to eq("1")
+        expect(assigns[:signature].jersey_resident).to eq("1")
         expect(assigns[:signature].postcode).to eq("SW1A1AA")
       end
 
@@ -149,7 +149,7 @@ RSpec.describe SignaturesController, type: :controller do
           {
             name: "Ted Berry",
             email: "",
-            uk_citizenship: "1",
+            jersey_resident: "1",
             postcode: "12345"
           }
         end
@@ -166,7 +166,7 @@ RSpec.describe SignaturesController, type: :controller do
       {
         name: "Ted Berry",
         email: "ted@example.com",
-        uk_citizenship: "1",
+        jersey_resident: "1",
         postcode: "SW1A 1AA"
       }
     end
@@ -230,7 +230,7 @@ RSpec.describe SignaturesController, type: :controller do
         it "sets the signature's params" do
           expect(assigns[:signature].name).to eq("Ted Berry")
           expect(assigns[:signature].email).to eq("ted@example.com")
-          expect(assigns[:signature].uk_citizenship).to eq("1")
+          expect(assigns[:signature].jersey_resident).to eq("1")
           expect(assigns[:signature].postcode).to eq("SW1A1AA")
         end
 
@@ -252,7 +252,7 @@ RSpec.describe SignaturesController, type: :controller do
             {
               name: "Ted Berry",
               email: "",
-              uk_citizenship: "1",
+              jersey_resident: "1",
               postcode: "SW1A 1AA"
             }
           end

--- a/spec/controllers/sponsors_controller_spec.rb
+++ b/spec/controllers/sponsors_controller_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe SponsorsController, type: :controller do
       {
         name: "Ted Berry",
         email: "ted@example.com",
-        uk_citizenship: "1",
+        jersey_resident: "1",
         postcode: "SW1A 1AA"
       }
     end
@@ -184,7 +184,7 @@ RSpec.describe SponsorsController, type: :controller do
         it "sets the signature's params" do
           expect(assigns[:signature].name).to eq("Ted Berry")
           expect(assigns[:signature].email).to eq("ted@example.com")
-          expect(assigns[:signature].uk_citizenship).to eq("1")
+          expect(assigns[:signature].jersey_resident).to eq("1")
           expect(assigns[:signature].postcode).to eq("SW1A1AA")
         end
 
@@ -201,7 +201,7 @@ RSpec.describe SponsorsController, type: :controller do
             {
               name: "Ted Berry",
               email: "",
-              uk_citizenship: "1",
+              jersey_resident: "1",
               postcode: "12345"
             }
           end
@@ -235,7 +235,7 @@ RSpec.describe SponsorsController, type: :controller do
       {
         name: "Ted Berry",
         email: "ted@example.com",
-        uk_citizenship: "1",
+        jersey_resident: "1",
         postcode: "SW1A 1AA"
       }
     end
@@ -310,7 +310,7 @@ RSpec.describe SponsorsController, type: :controller do
           it "sets the signature's params" do
             expect(assigns[:signature].name).to eq("Ted Berry")
             expect(assigns[:signature].email).to eq("ted@example.com")
-            expect(assigns[:signature].uk_citizenship).to eq("1")
+            expect(assigns[:signature].jersey_resident).to eq("1")
             expect(assigns[:signature].postcode).to eq("SW1A1AA")
           end
 
@@ -332,7 +332,7 @@ RSpec.describe SponsorsController, type: :controller do
               {
                 name: "Ted Berry",
                 email: "",
-                uk_citizenship: "1",
+                jersey_resident: "1",
                 postcode: "SW1A 1AA"
               }
             end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -423,7 +423,7 @@ FactoryBot.define do
     sequence(:name)  {|n| "Jo Public #{n}" }
     sequence(:email) {|n| "jo#{n}@public.com" }
     postcode              "SW1A 1AA"
-    uk_citizenship        "1"
+    jersey_resident       "1"
     notify_by_email       "1"
     state                 Signature::VALIDATED_STATE
 

--- a/spec/models/signature_spec.rb
+++ b/spec/models/signature_spec.rb
@@ -168,7 +168,7 @@ RSpec.describe Signature, type: :model do
           name: "Suzy Signer",
           email: email,
           postcode: postcode,
-          uk_citizenship: "1"
+          jersey_resident: "1"
         }
       end
 
@@ -246,7 +246,7 @@ RSpec.describe Signature, type: :model do
     end
 
     describe "postcode" do
-      it "requires a postcode for a UK address" do
+      it "requires a postcode" do
         expect(FactoryBot.build(:signature, :postcode => 'SW1A 1AA')).to be_valid
         expect(FactoryBot.build(:signature, :postcode => '')).not_to be_valid
       end
@@ -269,17 +269,17 @@ RSpec.describe Signature, type: :model do
       end
     end
 
-    describe "uk_citizenship" do
-      it "requires acceptance of uk_citizenship for a new record" do
-        expect(FactoryBot.build(:signature, :uk_citizenship => '1')).to be_valid
-        expect(FactoryBot.build(:signature, :uk_citizenship => '0')).not_to be_valid
-        expect(FactoryBot.build(:signature, :uk_citizenship => nil)).not_to be_valid
+    describe "jersey_resident" do
+      it "requires acceptance of jersey_resident for a new record" do
+        expect(FactoryBot.build(:signature, :jersey_resident => '1')).to be_valid
+        expect(FactoryBot.build(:signature, :jersey_resident => '0')).not_to be_valid
+        expect(FactoryBot.build(:signature, :jersey_resident => nil)).not_to be_valid
       end
 
-      it "does not require acceptance of uk_citizenship for old records" do
+      it "does not require acceptance of jersey_resident for old records" do
         sig = FactoryBot.create(:signature)
         sig.reload
-        sig.uk_citizenship = '0'
+        sig.jersey_resident = '0'
         expect(sig).to be_valid
       end
     end
@@ -1090,7 +1090,7 @@ RSpec.describe Signature, type: :model do
         name: "Suzy Signer",
         email: "suzy@example.com",
         postcode: postcode,
-        uk_citizenship: "1",
+        jersey_resident: "1",
         created_at: 2.days.ago,
         updated_at: 2.days.ago
       }
@@ -1158,7 +1158,7 @@ RSpec.describe Signature, type: :model do
         expect{ signature.validate! }.to raise_error(PG::InFailedSqlTransaction)
       end
 
-      context "and the signer is from the UK" do
+      context "and the signer is from Jersey" do
         context "and the postcode is valid" do
           let(:postcode) { "SW1A 1AA" }
 
@@ -1629,7 +1629,7 @@ RSpec.describe Signature, type: :model do
         name: name,
         email: email,
         postcode: postcode,
-        uk_citizenship: "1"
+        jersey_resident: "1"
       }
     end
 
@@ -1645,7 +1645,7 @@ RSpec.describe Signature, type: :model do
           name: "Suzy Signer",
           email: "foo@example.com",
           postcode: "SW1A 1AA",
-          uk_citizenship: "1"
+          jersey_resident: "1"
         )
       end
 
@@ -1719,14 +1719,14 @@ RSpec.describe Signature, type: :model do
           name: "Suzy Signer",
           email: "foo@example.com",
           postcode: "SW1A 1AA",
-          uk_citizenship: "1"
+          jersey_resident: "1"
         )
 
         petition.signatures.create!(
           name: "Sam Signer",
           email: "foo@example.com",
           postcode: "SW1A 1AA",
-          uk_citizenship: "1"
+          jersey_resident: "1"
         )
       end
 
@@ -1755,7 +1755,7 @@ RSpec.describe Signature, type: :model do
         name: "Suzy Signer",
         email: "foo@example.com",
         postcode: "SW1A 1AA",
-        uk_citizenship: "1"
+        jersey_resident: "1"
       }
     end
 

--- a/spec/requests/disallowed_format_spec.rb
+++ b/spec/requests/disallowed_format_spec.rb
@@ -375,7 +375,7 @@ RSpec.describe 'Requests for pages when we do not support the format on that pag
           'additional_details' => 'Global warming is upon us',
           'creator' => {
             'name' => 'John Mcenroe', 'email' => 'john@example.com',
-            'postcode' => 'SE3 4LL', 'uk_citizenship' => '1'
+            'postcode' => 'SE3 4LL', 'jersey_resident' => '1'
           }
         }
       }


### PR DESCRIPTION
The criteria for signing and creating petitions is different - only Jersey residents aged 16 or over are allowed so reflect that.