### PR TITLE
Replace references to government on homepage

### DIFF
--- a/app/views/pages/home/_explanation_petitions.html.erb
+++ b/app/views/pages/home/_explanation_petitions.html.erb
@@ -3,12 +3,12 @@
     <% if actioned[:with_response][:count].zero? %>
       <div class="threshold-panel threshold-panel-response">
         <h2 id="response-threshold-heading"><%= Site.formatted_threshold_for_response %></h2>
-        <p>If a petition gets <%= Site.formatted_threshold_for_response %> signatures, the government will respond</p>
+        <p>If a petition gets <%= Site.formatted_threshold_for_response %> signatures, the ministers will respond</p>
       </div>
     <% else %>
       <%= link_to( petitions_path(state: :with_response), class: "threshold-panel threshold-panel-response" ) do %>
         <h2 id="response-threshold-heading"><%= Site.formatted_threshold_for_response %></h2>
-        <p>If a petition gets <%= Site.formatted_threshold_for_response %> signatures, the government will respond</p>
+        <p>If a petition gets <%= Site.formatted_threshold_for_response %> signatures, the ministers will respond</p>
       <% end %>
     <% end %>
     <div class="section-panel-borderless">

--- a/app/views/pages/home/_responded_petitions.html.erb
+++ b/app/views/pages/home/_responded_petitions.html.erb
@@ -1,11 +1,11 @@
 <% if actioned[:awaiting_response][:count].zero? && actioned[:with_response][:count].zero? %>
-  <p>The government hasn’t responded to any petitions yet</p>
+  <p>The ministers haven’t responded to any petitions yet</p>
 <% else %>
   <ol class="threshold-petitions">
     <% actioned[:with_response][:list].each do |petition| %>
       <li class="petition-item">
         <h3><%= link_to petition.action, petition_path(petition, reveal_response: "yes", anchor: 'response-threshold'), class: "threshold-petition-title" %></h3>
-        <p class="intro">The government responded</p>
+        <p class="intro">The ministers responded</p>
         <blockquote class="pull-quote"><%= simple_format(petition.government_response.summary) %></blockquote>
         <p><%= link_to "Read the response in full", petition_path(petition, reveal_response: "yes", anchor: 'response-threshold') %></p>
       </li>

--- a/features/step_definitions/actioned_steps.rb
+++ b/features/step_definitions/actioned_steps.rb
@@ -39,10 +39,10 @@ Then(/^I should see a total showing (.*?) petitions debated in parliament$/) do 
   expect(page).to have_css(".actioned-petitions ul li:last-child .count", :text => debated_count)
 end
 
-Then(/^I should see an empty government response threshold section$/) do
+Then(/^I should see an empty ministers response threshold section$/) do
   within(:css, "section[aria-labelledby=response-threshold-heading]") do
     expect(page).to have_no_css("a[href='#{petitions_path(state: :with_response)}']")
-    expect(page).to have_content("The government hasn’t responded to any petitions yet")
+    expect(page).to have_content("The ministers haven’t responded to any petitions yet")
   end
 end
 

--- a/features/suzie_sees_actioned_petitions.feature
+++ b/features/suzie_sees_actioned_petitions.feature
@@ -6,7 +6,7 @@ Feature: Suzie sees actioned petitions
   Scenario: There are no actioned petitions
     Given I am on the home page
     Then I should not see the actioned petitions totals section
-    But I should see an empty government response threshold section
+    But I should see an empty ministers response threshold section
     And I should see an empty debate threshold section
 
   Scenario: There are petitions with a response from government
@@ -21,7 +21,7 @@ Feature: Suzie sees actioned petitions
     Given there are 3 petitions debated in parliament
     And I am on the home page
     Then I should see a total showing 3 petitions debated in parliament
-    And I should see an empty government response threshold section
+    And I should see an empty ministers response threshold section
     And I should see 3 petitions counted in the debate threshold section
     And I should see 3 petitions listed in the debate threshold section
 


### PR DESCRIPTION
A later story will replace government references across the entire app.

![screencapture-localhost-3000-2018-06-07-12_59_36](https://user-images.githubusercontent.com/1370570/41098246-a704cb3c-6a52-11e8-9eca-4e3e2ea886b0.png)
