### PR TITLE
Rename references to government & parliament

### DIFF
--- a/app/views/admin/admin/_petition_action_government_response.html.erb
+++ b/app/views/admin/admin/_petition_action_government_response.html.erb
@@ -1,1 +1,1 @@
-<%= link_to "Ministers' response", admin_petition_government_response_path(@petition), class: 'petition-action-heading' %>
+<%= link_to "Ministers' response", admin_petition_ministers_response_path(@petition), class: 'petition-action-heading' %>

--- a/app/views/admin/admin/_petition_action_government_response.html.erb
+++ b/app/views/admin/admin/_petition_action_government_response.html.erb
@@ -1,1 +1,1 @@
-<%= link_to 'Government response', admin_petition_government_response_path(@petition), class: 'petition-action-heading' %>
+<%= link_to "Ministers' response", admin_petition_government_response_path(@petition), class: 'petition-action-heading' %>

--- a/app/views/admin/government_response/_petition_action_government_response.html.erb
+++ b/app/views/admin/government_response/_petition_action_government_response.html.erb
@@ -1,5 +1,5 @@
 <h2 class="petition-action-heading">Ministers' response</h2>
-<%= form_for @government_response, :url => admin_petition_government_response_path(petition), method: :put do |f| -%>
+<%= form_for @government_response, :url => admin_petition_ministers_response_path(petition), method: :put do |f| -%>
   <%= form_row :for => [f.object, :summary] do %>
     <%= f.label :summary, 'Summary quote', class: 'form-label' %>
     <%= error_messages_for_field f.object, :summary %>

--- a/app/views/admin/government_response/_petition_action_government_response.html.erb
+++ b/app/views/admin/government_response/_petition_action_government_response.html.erb
@@ -1,4 +1,4 @@
-<h2 class="petition-action-heading">Government response</h2>
+<h2 class="petition-action-heading">Ministers' response</h2>
 <%= form_for @government_response, :url => admin_petition_government_response_path(petition), method: :put do |f| -%>
   <%= form_row :for => [f.object, :summary] do %>
     <%= f.label :summary, 'Summary quote', class: 'form-label' %>

--- a/app/views/admin/sites/_petitions.html.erb
+++ b/app/views/admin/sites/_petitions.html.erb
@@ -7,7 +7,7 @@
 <% end %>
 
 <%= form_row for: [form.object, :threshold_for_response] do %>
-  <%= form.label :threshold_for_response, "Threshold for government response", class: "form-label" %>
+  <%= form.label :threshold_for_response, "Threshold for response from Ministers", class: "form-label" %>
   <%= error_messages_for_field @site, :threshold_for_response %>
   <%= form.text_field :threshold_for_response, tabindex: increment, maxlength: 10, class: "form-control form-control-1-4" %>
 <% end %>

--- a/app/views/application/_messages.html.erb
+++ b/app/views/application/_messages.html.erb
@@ -1,4 +1,3 @@
 <% if flash[:notice] %>
   <p class="flash-notice"><%= flash[:notice] %></p>
 <% end %>
-a

--- a/app/views/application/_social_meta.html.erb
+++ b/app/views/application/_social_meta.html.erb
@@ -23,5 +23,5 @@
 <%= twitter_card_tag 'description', @petition.background %>
 <% else %>
 <%= twitter_card_tag 'title', page_title %>
-<%= twitter_card_tag 'description', 'Official online petitions in response to issues of the day, listing the number that got a Government response, and those that have been debated in the House of Parliament' %>
+<%= twitter_card_tag 'description', 'Official online petitions in response to issues of the day, listing the number that got a response from ministers, and those that have been debated in the States Assembly' %>
 <% end %>

--- a/app/views/pages/help.html.erb
+++ b/app/views/pages/help.html.erb
@@ -6,8 +6,8 @@
   <li>You create a petition. Only Jersey residents aged over 16 can create or sign a petition.</li>
   <li>You get 5 people to support your petition. We’ll tell you how to do this when you’ve created your petition.</li>
   <li>We check your petition, then publish it. We only reject petitions that don’t meet the standards for petitions.</li>
-  <li>States Members see all the petitions we publish. They can find out more about the issues raised by petitions. They have the power to press for action from ministers or the States Assembly.</li>
-  <li>At 1,000 signatures you get a response from the government.</li>
+  <li>States Members see all the petitions we publish. They can find out more about the issues raised by petitions. They have the power to press for action from Ministers or the States Assembly.</li>
+  <li>At 1,000 signatures you get a response from the inisters.</li>
   <li>At 5,000 signatures your petition will be considered for a debate in the States Assembly.</li>
 </ol>
 
@@ -19,11 +19,11 @@
 
 <h2 id="standards">Standards for petitions</h2>
 
-<p>Petitions must call for a specific action from Jersey ministers or the States Assembly.</p>
+<p>Petitions must call for a specific action from Jersey Ministers or the States Assembly.</p>
 
 <p>Petitions must be about something that the States Assembly is responsible for.</p>
 
-<p>Petitions can disagree with ministers and can ask for policies to be changed. Petitions can be critical of Jersey ministers or the States Assembly.</p>
+<p>Petitions can disagree with Ministers and can ask for policies to be changed. Petitions can be critical of Jersey Ministers or the States Assembly.</p>
 
 <p>We reject petitions that don’t meet the rules. If we reject your petition, we’ll tell you why. If we can, we’ll suggest other ways you could raise your issue.</p>
 
@@ -34,10 +34,10 @@
     <p>It calls for the same action as a petition that’s already open</p>
   </li>
   <li>
-    <p>It doesn’t ask for a clear action from Jersey ministers or the States Assembly</p>
+    <p>It doesn’t ask for a clear action from Jersey Ministers or the States Assembly</p>
   </li>
   <li>
-    <p>It’s about something Jersey ministers or the States Assembly are not responsible for.</p>
+    <p>It’s about something Jersey Ministers or the States Assembly are not responsible for.</p>
     <p>That includes: something that another Government (such as the UK Government) is responsible for and something that an independent organisation has done.</p>
   </li>
   <li>

--- a/app/views/pages/home/_explanation_petitions.html.erb
+++ b/app/views/pages/home/_explanation_petitions.html.erb
@@ -3,12 +3,12 @@
     <% if actioned[:with_response][:count].zero? %>
       <div class="threshold-panel threshold-panel-response">
         <h2 id="response-threshold-heading"><%= Site.formatted_threshold_for_response %></h2>
-        <p>If a petition gets <%= Site.formatted_threshold_for_response %> signatures, the ministers will respond</p>
+        <p>If a petition gets <%= Site.formatted_threshold_for_response %> signatures, the Ministers will respond</p>
       </div>
     <% else %>
       <%= link_to( petitions_path(state: :with_response), class: "threshold-panel threshold-panel-response" ) do %>
         <h2 id="response-threshold-heading"><%= Site.formatted_threshold_for_response %></h2>
-        <p>If a petition gets <%= Site.formatted_threshold_for_response %> signatures, the ministers will respond</p>
+        <p>If a petition gets <%= Site.formatted_threshold_for_response %> signatures, the Ministers will respond</p>
       <% end %>
     <% end %>
     <div class="section-panel-borderless">

--- a/app/views/pages/home/_responded_petitions.html.erb
+++ b/app/views/pages/home/_responded_petitions.html.erb
@@ -1,11 +1,11 @@
 <% if actioned[:awaiting_response][:count].zero? && actioned[:with_response][:count].zero? %>
-  <p>The ministers haven’t responded to any petitions yet</p>
+  <p>The Ministers haven’t responded to any petitions yet</p>
 <% else %>
   <ol class="threshold-petitions">
     <% actioned[:with_response][:list].each do |petition| %>
       <li class="petition-item">
         <h3><%= link_to petition.action, petition_path(petition, reveal_response: "yes", anchor: 'response-threshold'), class: "threshold-petition-title" %></h3>
-        <p class="intro">The ministers responded</p>
+        <p class="intro">The Ministers responded</p>
         <blockquote class="pull-quote"><%= simple_format(petition.government_response.summary) %></blockquote>
         <p><%= link_to "Read the response in full", petition_path(petition, reveal_response: "yes", anchor: 'response-threshold') %></p>
       </li>

--- a/app/views/petition_mailer/notify_creator_of_debate_outcome.html.erb
+++ b/app/views/petition_mailer/notify_creator_of_debate_outcome.html.erb
@@ -5,7 +5,7 @@
 <p>Dear <%= @signature.name %>,</p>
 
 <% if @debate_outcome.debated? %>
-<p>Parliament debated your petition – “<%= @petition.action %>”</p>
+<p>States Assembly debated your petition – “<%= @petition.action %>”</p>
 <% if @debate_outcome.overview? %>
 
 <blockquote><%= auto_link(simple_format(h(@debate_outcome.overview))) %></blockquote>

--- a/app/views/petition_mailer/notify_creator_of_debate_outcome.text.erb
+++ b/app/views/petition_mailer/notify_creator_of_debate_outcome.text.erb
@@ -5,7 +5,7 @@ To unsubscribe from getting emails about this petition: <%= unsubscribe_signatur
 Dear <%= @signature.name %>,
 
 <% if @debate_outcome.debated? %>
-Parliament debated your petition – “<%= @petition.action %>”
+States Assembly debated your petition – “<%= @petition.action %>”
 
 <% if @debate_outcome.overview? %>
 <%= @debate_outcome.overview %>

--- a/app/views/petition_mailer/notify_creator_of_debate_scheduled.html.erb
+++ b/app/views/petition_mailer/notify_creator_of_debate_scheduled.html.erb
@@ -4,7 +4,7 @@
 
 <p>Dear <%= @signature.name %>,</p>
 
-<p>Parliament is going to debate your petition – “<%= @petition.action %>”.</p>
+<p>States Assembly is going to debate your petition – “<%= @petition.action %>”.</p>
 
 <p><%= link_to nil, petition_url(@petition) %></p>
 

--- a/app/views/petition_mailer/notify_creator_of_debate_scheduled.text.erb
+++ b/app/views/petition_mailer/notify_creator_of_debate_scheduled.text.erb
@@ -4,7 +4,7 @@ To unsubscribe from getting emails about this petition: <%= unsubscribe_signatur
 
 Dear <%= @signature.name %>,
 
-Parliament is going to debate your petition – “<%= @petition.action %>”.
+States Assembly is going to debate your petition – “<%= @petition.action %>”.
 
 <%= petition_url(@petition) %>
 

--- a/app/views/petition_mailer/notify_creator_of_threshold_response.html.erb
+++ b/app/views/petition_mailer/notify_creator_of_threshold_response.html.erb
@@ -17,12 +17,10 @@
 <p><%= link_to nil, petition_url(@petition, reveal_response: "yes") %></p>
 
 <% if @petition.signature_count < Site.threshold_for_debate %>
-<p>The Petitions Committee will take a look at this petition and its response. They can press the government for action and gather evidence. If this petition reaches <%= Site.formatted_threshold_for_debate %> signatures, the Committee will consider it for a debate.</p>
+<p>The Petitions Committee will take a look at this petition and its response. They can press the ministers for action and gather evidence. If this petition reaches <%= Site.formatted_threshold_for_debate %> signatures, the Committee will consider it for a debate.</p>
 <% else %>
-<p>This petition has over <%= Site.formatted_threshold_for_debate %> signatures. The Petitions Committee will consider it for a debate. They can also gather further evidence and press the government for action.</p>
+<p>This petition has over <%= Site.formatted_threshold_for_debate %> signatures. The Petitions Committee will consider it for a debate. They can also gather further evidence and press the ministers for action.</p>
 <% end %>
-
-<p>The Committee is made up of 11 MPs, from political parties in government and in opposition. It is entirely independent of the Government. Find out more about the Committee: <%= link_to nil, help_url(anchor: 'petitions-committee') %></p>
 
 <p>Thanks,<br />
 <%= t("petitions.emails.signoff_prefix") %><br />

--- a/app/views/petition_mailer/notify_creator_of_threshold_response.text.erb
+++ b/app/views/petition_mailer/notify_creator_of_threshold_response.text.erb
@@ -4,9 +4,9 @@ To unsubscribe from getting emails about this petition: <%= unsubscribe_signatur
 
 Dear <%= @signature.name %>,
 
-The Government has responded to your petition – “<%= @petition.action %>”.
+The Ministers have responded to your petition – “<%= @petition.action %>”.
 
-Government responded:
+Ministers responded:
 
 <%= h(@government_response.summary) %>
 
@@ -17,12 +17,10 @@ Click this link to view the response online:
 <%= petition_url(@petition, reveal_response: "yes") %>
 
 <% if @petition.signature_count < Site.threshold_for_debate %>
-The Petitions Committee will take a look at this petition and its response. They can press the government for action and gather evidence. If this petition reaches <%= Site.formatted_threshold_for_debate %> signatures, the Committee will consider it for a debate.
+The Petitions Committee will take a look at this petition and its response. They can press the ministers for action and gather evidence. If this petition reaches <%= Site.formatted_threshold_for_debate %> signatures, the Committee will consider it for a debate.
 <% else %>
-This petition has over <%= Site.formatted_threshold_for_debate %> signatures. The Petitions Committee will consider it for a debate. They can also gather further evidence and press the government for action.
+This petition has over <%= Site.formatted_threshold_for_debate %> signatures. The Petitions Committee will consider it for a debate. They can also gather further evidence and press the ministers for action.
 <% end %>
-
-The Committee is made up of 11 MPs, from political parties in government and in opposition. It is entirely independent of the Government. Find out more about the Committee: <%= help_url(anchor: 'petitions-committee') %>
 
 Thanks,
 <%= t("petitions.emails.signoff_prefix") %>

--- a/app/views/petition_mailer/notify_signer_of_debate_outcome.html.erb
+++ b/app/views/petition_mailer/notify_signer_of_debate_outcome.html.erb
@@ -5,7 +5,7 @@
 <p>Dear <%= @signature.name %>,</p>
 
 <% if @debate_outcome.debated? %>
-<p>Parliament debated the petition you signed – “<%= @petition.action %>”</p>
+<p>States Assembly debated the petition you signed – “<%= @petition.action %>”</p>
 <% if @debate_outcome.overview? %>
 
 <blockquote><%= auto_link(simple_format(h(@debate_outcome.overview))) %></blockquote>

--- a/app/views/petition_mailer/notify_signer_of_debate_outcome.text.erb
+++ b/app/views/petition_mailer/notify_signer_of_debate_outcome.text.erb
@@ -5,7 +5,7 @@ To unsubscribe from getting emails about this petition: <%= unsubscribe_signatur
 Dear <%= @signature.name %>,
 
 <% if @debate_outcome.debated? %>
-Parliament debated the petition you signed – “<%= @petition.action %>”
+States Assembly debated the petition you signed – “<%= @petition.action %>”
 
 <% if @debate_outcome.overview? %>
 <%= @debate_outcome.overview %>

--- a/app/views/petition_mailer/notify_signer_of_debate_scheduled.html.erb
+++ b/app/views/petition_mailer/notify_signer_of_debate_scheduled.html.erb
@@ -4,7 +4,7 @@
 
 <p>Dear <%= @signature.name %>,</p>
 
-<p>Parliament is going to debate the petition you signed – “<%= @petition.action %>”.</p>
+<p>States Assembly is going to debate the petition you signed – “<%= @petition.action %>”.</p>
 
 <p><%= link_to nil, petition_url(@petition) %></p>
 

--- a/app/views/petition_mailer/notify_signer_of_debate_scheduled.text.erb
+++ b/app/views/petition_mailer/notify_signer_of_debate_scheduled.text.erb
@@ -4,7 +4,7 @@ To unsubscribe from getting emails about this petition: <%= unsubscribe_signatur
 
 Dear <%= @signature.name %>,
 
-Parliament is going to debate the petition you signed – “<%= @petition.action %>”.
+States Assembly is going to debate the petition you signed – “<%= @petition.action %>”.
 
 <%= petition_url(@petition) %>
 

--- a/app/views/petition_mailer/notify_signer_of_threshold_response.html.erb
+++ b/app/views/petition_mailer/notify_signer_of_threshold_response.html.erb
@@ -4,9 +4,9 @@
 
 <p>Dear <%= @signature.name %>,</p>
 
-<p>The Government has responded to the petition you signed – “<%= link_to @petition.action, petition_url(@petition) %>”.</p>
+<p>Ministers have responded to the petition you signed – “<%= link_to @petition.action, petition_url(@petition) %>”.</p>
 
-<p>Government responded:</p>
+<p>Ministers responded:</p>
 
 <blockquote><%= auto_link(simple_format(h(@government_response.summary))) %></blockquote>
 
@@ -17,12 +17,12 @@
 <p><%= link_to nil, petition_url(@petition, reveal_response: "yes") %></p>
 
 <% if @petition.signature_count < Site.threshold_for_debate %>
-<p>The Petitions Committee will take a look at this petition and its response. They can press the government for action and gather evidence. If this petition reaches <%= Site.formatted_threshold_for_debate %> signatures, the Committee will consider it for a debate.</p>
+<p>The Petitions Committee will take a look at this petition and its response. They can press ministers for action and gather evidence. If this petition reaches <%= Site.formatted_threshold_for_debate %> signatures, the Committee will consider it for a debate.</p>
 <% else %>
-<p>This petition has over <%= Site.formatted_threshold_for_debate %> signatures. The Petitions Committee will consider it for a debate. They can also gather further evidence and press the government for action.</p>
+<p>This petition has over <%= Site.formatted_threshold_for_debate %> signatures. The Petitions Committee will consider it for a debate. They can also gather further evidence and press ministers for action.</p>
 <% end %>
 
-<p>The Committee is made up of 11 MPs, from political parties in government and in opposition. It is entirely independent of the Government. Find out more about the Committee: <%= link_to nil, help_url(anchor: 'petitions-committee') %></p>
+<p>Find out more about the Committee: <%= link_to nil, help_url(anchor: 'petitions-committee') %></p>
 
 <p>Thanks,<br />
 <%= t("petitions.emails.signoff_prefix") %><br />

--- a/app/views/petition_mailer/notify_signer_of_threshold_response.text.erb
+++ b/app/views/petition_mailer/notify_signer_of_threshold_response.text.erb
@@ -4,9 +4,9 @@ To unsubscribe from getting emails about this petition: <%= unsubscribe_signatur
 
 Dear <%= @signature.name %>,
 
-The Government has responded to the petition you signed – “<%= @petition.action %>”.
+Ministers have responded to the petition you signed – “<%= @petition.action %>”.
 
-Government responded:
+Ministers responded:
 
 <%= h(@government_response.summary) %>
 
@@ -17,12 +17,10 @@ Click this link to view the response online:
 <%= petition_url(@petition, reveal_response: "yes") %>
 
 <% if @petition.signature_count < Site.threshold_for_debate %>
-The Petitions Committee will take a look at this petition and its response. They can press the government for action and gather evidence. If this petition reaches <%= Site.formatted_threshold_for_debate %> signatures, the Committee will consider it for a debate.
+The Petitions Committee will take a look at this petition and its response. They can press the ministers for action and gather evidence. If this petition reaches <%= Site.formatted_threshold_for_debate %> signatures, the Committee will consider it for a debate.
 <% else %>
-This petition has over <%= Site.formatted_threshold_for_debate %> signatures. The Petitions Committee will consider it for a debate. They can also gather further evidence and press the government for action.
+This petition has over <%= Site.formatted_threshold_for_debate %> signatures. The Petitions Committee will consider it for a debate. They can also gather further evidence and press the ministers for action.
 <% end %>
-
-The Committee is made up of 11 MPs, from political parties in government and in opposition. It is entirely independent of the Government. Find out more about the Committee: <%= help_url(anchor: 'petitions-committee') %>
 
 Thanks,
 <%= t("petitions.emails.signoff_prefix") %>

--- a/app/views/petitions/_action_help.html.erb
+++ b/app/views/petitions/_action_help.html.erb
@@ -12,6 +12,6 @@
       <li>Russia Problem on US ruling</li>
       <li>Justice for David Thomas</li>
     </ul>
-    <p>Good petitions say clearly what they want government or parliament to do.</p>
+    <p>Good petitions say clearly what they want Ministers to do.</p>
   </div>
 </details>

--- a/app/views/petitions/_debate_threshold.html.erb
+++ b/app/views/petitions/_debate_threshold.html.erb
@@ -57,7 +57,7 @@
       </p>
     <% end %>
 
-  <%# Waiting for a government response #%>
+  <%# Waiting for a ministers response #%>
   <% elsif petition.debate_threshold_reached_at? -%>
     <h2 id="debate-threshold-heading">The States Assembly will consider this for a debate</h2>
     <p>The States Assembly considers all petitions that get more than <%= Site.formatted_threshold_for_debate %> signatures for a debate</p>

--- a/app/views/petitions/_debate_threshold.html.erb
+++ b/app/views/petitions/_debate_threshold.html.erb
@@ -42,7 +42,7 @@
         The States Assembly debated this petition on <%= short_date_format(petition.scheduled_debate_date) %>
       </p>
       <p>
-        You'll be able to watch the debate online at <a href="http://parliamentlive.tv" rel="external">parliamentlive.tv</a>
+        You'll be able to watch the debate online at <a href="https://statesassembly.public-i.tv/core/portal/home" rel="external">statesassembly.public-i.tv</a>
       </p>
       <p class="secondary"><%= waiting_for_in_words(petition.scheduled_debate_date) %> for the States Assembly to publish the debate outcome</p>
 
@@ -53,7 +53,7 @@
         The States Assembly will debate this petition on <%= short_date_format(petition.scheduled_debate_date) %>.
       </p>
       <p>
-        You'll be able to watch online at <a href="http://parliamentlive.tv" rel="external">parliamentlive.tv</a>
+        You'll be able to watch online at  <a href="https://statesassembly.public-i.tv/core/portal/home" rel="external">statesassembly.public-i.tv</a>
       </p>
     <% end %>
 

--- a/app/views/petitions/_petition.json.jbuilder
+++ b/app/views/petitions/_petition.json.jbuilder
@@ -19,7 +19,7 @@ json.attributes do
   json.closed_at api_date_format(petition.closed_at)
   json.moderation_threshold_reached_at api_date_format(petition.moderation_threshold_reached_at)
   json.response_threshold_reached_at api_date_format(petition.response_threshold_reached_at)
-  json.government_response_at api_date_format(petition.government_response_at)
+  json.ministers_response_at api_date_format(petition.government_response_at)
   json.debate_threshold_reached_at api_date_format(petition.debate_threshold_reached_at)
   json.scheduled_debate_date api_date_format(petition.scheduled_debate_date)
   json.debate_outcome_at api_date_format(petition.debate_outcome_at)
@@ -40,14 +40,14 @@ json.attributes do
   end
 
   if response = petition.government_response
-    json.government_response do
+    json.ministers_response do
       json.summary response.summary
       json.details response.details
       json.created_at api_date_format(response.created_at)
       json.updated_at api_date_format(response.updated_at)
     end
   else
-    json.government_response nil
+    json.ministers_reponse nil
   end
 
   if debate_outcome = petition.debate_outcome

--- a/app/views/petitions/_response_threshold.html.erb
+++ b/app/views/petitions/_response_threshold.html.erb
@@ -1,7 +1,7 @@
 <section class="about-item about-item-count-response" id="response-threshold" aria-labelledby="response-threshold-heading">
-  <%# Has a government response #%>
+  <%# Has a Ministers response #%>
   <% if government_response = petition.government_response? -%>
-    <h2 id="response-threshold-heading">Government responded</h2>
+    <h2 id="response-threshold-heading">Ministers responded</h2>
     <blockquote class="pull-quote">
       <%= auto_link(simple_format(h(government_response.summary)), html: { rel: 'nofollow' } ) %>
     </blockquote>
@@ -19,17 +19,17 @@
       <% end -%>
     <% end -%>
 
-  <%# Waiting for a government response #%>
+  <%# Waiting for a Ministers response #%>
   <% elsif petition.response_threshold_reached_at? -%>
-    <h2 id="response-threshold-heading">Government will respond</h2>
-    <p>Government responds to all petitions that get more than <%= Site.formatted_threshold_for_response %> signatures</p>
-    <p class="secondary"><%= waiting_for_in_words(petition.response_threshold_reached_at) %> for a government response</p>
+    <h2 id="response-threshold-heading">Ministers will respond</h2>
+    <p>Ministers respond to all petitions that get more than <%= Site.formatted_threshold_for_response %> signatures</p>
+    <p class="secondary"><%= waiting_for_in_words(petition.response_threshold_reached_at) %> for a response from Ministers</p>
 
   <%# Needs more signatures #%>
   <% else -%>
     <% if !@petition.closed? %>
       <h2 id="response-threshold-heading">At <%= Site.formatted_threshold_for_response %> signatures...</h2>
-      <p>At <%= Site.formatted_threshold_for_response %> signatures, government will respond to this petition</p>
+      <p>At <%= Site.formatted_threshold_for_response %> signatures, the Ministers will respond to this petition</p>
     <% end %>
   <% end -%>
 </section>

--- a/app/views/petitions/search/result_items/_petition_result_for_facet_with_response.html.erb
+++ b/app/views/petitions/search/result_items/_petition_result_for_facet_with_response.html.erb
@@ -1,4 +1,4 @@
 <h3><%= link_to petition.action, petition_path(petition, reveal_response: "yes", anchor: 'response-threshold') %></h3>
-<p>Government responded – <%= short_date_format(petition.government_response_at) %></p>
+<p>Ministers responded – <%= short_date_format(petition.government_response_at) %></p>
 <p><%= petition.government_response.summary %></p>
 <p><%= signature_count(:default, petition.signature_count) %></p>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -35,7 +35,7 @@ Rails.application.configure do
 
   # Asset digests allow you to set far-future HTTP expiration dates on all assets,
   # yet still be able to expire them through the digest params.
-  config.assets.digest = true
+  config.assets.digest = false
 
   # Adds additional error checking when serving assets at runtime.
   # Checks for improperly declared sprockets dependencies.

--- a/config/locales/admin.en-GB.yml
+++ b/config/locales/admin.en-GB.yml
@@ -61,7 +61,7 @@ en-GB:
       moderation_delay_preview_sent: "A preview email of the moderation delay has been sent to the feedback address"
       missing_tasks: "Please select one or more tasks to execute"
       password_updated: "Password was successfully updated"
-      parliament_updated: "Parliament updated successfully"
+      parliament_updated: "States Assembly updated successfully"
       petition_email_created: "Created other parliamentary business successfully"
       petition_email_updated: "Updated other parliamentary business successfully"
       petition_email_deleted: "Deleted other parliamentary business successfully"

--- a/config/locales/admin.en-GB.yml
+++ b/config/locales/admin.en-GB.yml
@@ -36,7 +36,7 @@ en-GB:
       debate_date_updated: "Updated the scheduled debate date successfully"
       debate_outcome_updated: "Updated debate outcome successfully"
       email_sent_overnight: "Email will be sent overnight"
-      government_response_updated: "Updated government response successfully"
+      government_response_updated: "Updated Ministers' response successfully"
       failed_tasks: "There was a problem starting the tasks - please contact support"
       invalidation_cant_be_cancelled: "Can't cancel invalidations that have completed"
       invalidation_cant_be_counted: "Can't count invalidations that aren't pending"

--- a/config/locales/petitions.en-GB.yml
+++ b/config/locales/petitions.en-GB.yml
@@ -15,8 +15,8 @@ en-GB:
       closed: "Closed petitions"
       rejected: "Rejected petitions"
       published: "Published petitions"
-      awaiting_response: "Petitions waiting for a Government response"
-      with_response: "Petitions with a Government response"
+      awaiting_response: "Petitions waiting for a response from Ministers"
+      with_response: "Petitions with response"
       debated: "Petitions debated in the States Assembly"
       not_debated: "Petitions not debated in the States Assembly"
       awaiting_debate: "Petitions waiting for a debate in the States Assembly"
@@ -39,8 +39,8 @@ en-GB:
       closed: "Closed petitions (%{quantity})"
       published: "Published petitions (%{quantity})"
       rejected: "Rejected petitions (%{quantity})"
-      awaiting_response: "Awaiting government response (%{quantity})"
-      with_response: "Government responses (%{quantity})"
+      awaiting_response: "Awaiting response from Ministers (%{quantity})"
+      with_response: "Ministers' responses (%{quantity})"
       debated: "Debated in the States Assembly (%{quantity})"
       not_debated: "Not debated in the States Assembly (%{quantity})"
       awaiting_debate: "Awaiting a debate in the States Assembly (%{quantity})"
@@ -91,8 +91,8 @@ en-GB:
           closed: "Closed (%{quantity})"
           rejected: "Rejected (%{quantity})"
           hidden: "Hidden (%{quantity})"
-          awaiting_response: "Awaiting a government response (%{quantity})"
-          with_response: "With a government response (%{quantity})"
+          awaiting_response: "Awaiting a response from Ministers (%{quantity})"
+          with_response: "With a response from Ministers (%{quantity})"
           awaiting_debate_date: "Awaiting a debate in parliament (%{quantity})"
           with_debate_outcome: "Has been debated in parliament (%{quantity})"
           in_debate_queue: "In debate queue (%{quantity})"
@@ -113,7 +113,7 @@ en-GB:
         notify_signer_of_debate_scheduled: |-
           Parliament will debate “%{action}”
         notify_signer_of_threshold_response: |-
-          Government responded to “%{action}”
+          Ministers responded to “%{action}”
 
         # Emails to people who create petitions
         email_creator: |-
@@ -125,7 +125,7 @@ en-GB:
         notify_creator_of_debate_scheduled: |-
           Parliament will debate “%{action}”
         notify_creator_of_threshold_response: |-
-          Government responded to “%{action}”
+          Ministers responded to “%{action}”
         notify_creator_that_moderation_is_delayed: |-
           %{subject}
 
@@ -178,12 +178,12 @@ en-GB:
     counts:
       awaiting_response:
         html:
-          one: "<span class=\"count\">%{formatted_count}</span> petition is waiting for a response from the ministers"
-          other: "<span class=\"count\">%{formatted_count}</span> petitions are waiting for responses from the ministers"
+          one: "<span class=\"count\">%{formatted_count}</span> petition is waiting for a response from the Ministers"
+          other: "<span class=\"count\">%{formatted_count}</span> petitions are waiting for responses from the Ministers"
       with_response:
         html:
-          one: "<span class=\"count\">%{formatted_count}</span> petition got a response from the ministers"
-          other: "<span class=\"count\">%{formatted_count}</span> petitions got a response from the ministers"
+          one: "<span class=\"count\">%{formatted_count}</span> petition got a response from the Ministers"
+          other: "<span class=\"count\">%{formatted_count}</span> petitions got a response from the Ministers"
       awaiting_debate:
         html:
           one: "<span class=\"count\">%{formatted_count}</span> petition is waiting to be considered for debate"
@@ -193,9 +193,9 @@ en-GB:
           one: "<span class=\"count\">%{formatted_count}</span> petition was debated in the States Assembly"
           other: "<span class=\"count\">%{formatted_count}</span> petitions were debated in the States Assembly"
       awaiting_response_explanation:
-        html: "See all petitions waiting for a response from ministers (%{formatted_count})"
+        html: "See all petitions waiting for a response from Ministers (%{formatted_count})"
       with_response_explanation:
-        html: "See all petitions with a response from ministers (%{formatted_count})"
+        html: "See all petitions with a response from Ministers (%{formatted_count})"
       awaiting_debate_explanation:
         html: "See all petitions waiting for a debate (%{formatted_count})"
       debated_explanation:

--- a/config/locales/petitions.en-GB.yml
+++ b/config/locales/petitions.en-GB.yml
@@ -93,8 +93,8 @@ en-GB:
           hidden: "Hidden (%{quantity})"
           awaiting_response: "Awaiting a response from Ministers (%{quantity})"
           with_response: "With a response from Ministers (%{quantity})"
-          awaiting_debate_date: "Awaiting a debate in parliament (%{quantity})"
-          with_debate_outcome: "Has been debated in parliament (%{quantity})"
+          awaiting_debate_date: "Awaiting a debate in States Assembly (%{quantity})"
+          with_debate_outcome: "Has been debated in States Assembly (%{quantity})"
           in_debate_queue: "In debate queue (%{quantity})"
 
     emails:
@@ -107,11 +107,11 @@ en-GB:
         email_duplicate_signatures: |-
           Duplicate signature of petition
         notify_signer_of_positive_debate_outcome: |-
-          Parliament debated “%{action}”
+          States Assembly debated “%{action}”
         notify_signer_of_negative_debate_outcome: |-
-          Parliament didn’t debate “%{action}”
+          States Assembly didn’t debate “%{action}”
         notify_signer_of_debate_scheduled: |-
-          Parliament will debate “%{action}”
+          States Assembly will debate “%{action}”
         notify_signer_of_threshold_response: |-
           Ministers responded to “%{action}”
 
@@ -119,11 +119,11 @@ en-GB:
         email_creator: |-
           %{subject}
         notify_creator_of_positive_debate_outcome: |-
-          Parliament debated “%{action}”
+          States Assembly debated “%{action}”
         notify_creator_of_negative_debate_outcome: |-
-          Parliament didn’t debate “%{action}”
+          States Assembly didn’t debate “%{action}”
         notify_creator_of_debate_scheduled: |-
-          Parliament will debate “%{action}”
+          States Assembly will debate “%{action}”
         notify_creator_of_threshold_response: |-
           Ministers responded to “%{action}”
         notify_creator_that_moderation_is_delayed: |-

--- a/config/locales/rejections.en-GB.yml
+++ b/config/locales/rejections.en-GB.yml
@@ -2,7 +2,7 @@ en-GB:
   rejections:
     titles:
       duplicate: "Duplicate petition"
-      irrelevant: "Not the Government/Parliament’s responsibility"
+      irrelevant: "Not the Ministers'/States Assembly's responsibility"
       no-action: "Action unclear"
       honours: "Honours or appointments"
       fake-name: "Fake name"
@@ -14,9 +14,9 @@ en-GB:
         <p>There’s already a petition about this issue. We cannot accept a new petition when we already have one about a very similar issue.</p>
         <p>You are more likely to get action on this issue if you sign and share a single petition.</p>
       irrelevant: |-
-        <p>It’s about something that the UK Government or Parliament is not responsible for.</p>
+        <p>It’s about something that Ministers or the States Assembly is not responsible for.</p>
       no-action: |-
-        <p>It’s not clear what the petition is asking the UK Government or Parliament to do.</p>
+        <p>It’s not clear what the petition is asking Ministers or States Assembly to do.</p>
       honours: |-
         <p>It’s about honours or appointments.</p>
       fake-name: |-

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -100,7 +100,7 @@ Rails.application.routes.draw do
 
         scope only: %i[show update] do
           resource :debate_outcome, path: 'debate-outcome'
-          resource :government_response, path: 'government-response', controller: 'government_response'
+          resource :government_response, path: 'ministers-response', controller: 'government_response', as: 'ministers_response'
           resource :notes
           resource :details, controller: 'petition_details'
           resource :schedule_debate, path: 'schedule-debate', controller: 'schedule_debate'

--- a/features/admin/admin_hub.feature
+++ b/features/admin/admin_hub.feature
@@ -9,7 +9,7 @@ Feature: Admin hub page
 
   Scenario: I can see a total of petitions needing moderation and link to them
     Given 20 petitions exist with state: "sponsored"
-    And there are 12 petitions awaiting a government response
+    And there are 12 petitions awaiting a Ministers response
     And there are 5 petitions with a scheduled debate date
     And there are 3 petitions with enough signatures to require a debate
     When I go to the Admin home page

--- a/features/admin/all_petitions.feature
+++ b/features/admin/all_petitions.feature
@@ -94,11 +94,11 @@ Feature: A moderator user views all petitions
     Then I should see the following list of petitions:
      | My open petition with Ministers response |
 
-    And I filter the list to show "Awaiting a debate in parliament" petitions
+    And I filter the list to show "Awaiting a debate in States Assembly" petitions
     Then I should see the following list of petitions:
      | My open petition awaiting debate date |
 
-    And I filter the list to show "Has been debated in parliament" petitions
+    And I filter the list to show "Has been debated in States Assembly" petitions
     Then I should see the following list of petitions:
      | My open petition with debate outcome |
 

--- a/features/admin/all_petitions.feature
+++ b/features/admin/all_petitions.feature
@@ -33,15 +33,15 @@ Feature: A moderator user views all petitions
 
     And a petition "My open petition with debate outcome" exists with a debate outcome
     And a petition "My open petition awaiting debate date" exists awaiting debate date
-    And a petition "My open petition with government response" exists with government response
-    And a petition "My open petition awaiting government response" exists awaiting government response
+    And a petition "My open petition with Ministers response" exists with Ministers response
+    And a petition "My open petition awaiting Ministers response" exists awaiting Ministers response
     And a petition "My open petition with scheduled debate date" with scheduled debate date of "23/10/2010"
 
     When I view all petitions
     Then I should see the following list of petitions:
      | My open petition with scheduled debate date   |
-     | My open petition awaiting government response |
-     | My open petition with government response     |
+     | My open petition awaiting Ministers response |
+     | My open petition with Ministers response     |
      | My open petition awaiting debate date         |
      | My open petition with debate outcome          |
      | My hidden petition                            |
@@ -68,8 +68,8 @@ Feature: A moderator user views all petitions
     And I filter the list to show "Open" petitions
     Then I should see the following list of petitions:
      | My open petition with scheduled debate date   |
-     | My open petition awaiting government response |
-     | My open petition with government response     |
+     | My open petition awaiting Ministers response |
+     | My open petition with Ministers response     |
      | My open petition awaiting debate date         |
      | My open petition with debate outcome          |
      | My open petition                              |
@@ -86,13 +86,13 @@ Feature: A moderator user views all petitions
     Then I should see the following list of petitions:
      | My hidden petition |
 
-    And I filter the list to show "Awaiting a government response" petitions
+    And I filter the list to show "Awaiting a response from Ministers" petitions
     Then I should see the following list of petitions:
-     | My open petition awaiting government response |
+     | My open petition awaiting Ministers response |
 
-    And I filter the list to show "With a government response" petitions
+    And I filter the list to show "With a response from Ministers" petitions
     Then I should see the following list of petitions:
-     | My open petition with government response |
+     | My open petition with Ministers response |
 
     And I filter the list to show "Awaiting a debate in parliament" petitions
     Then I should see the following list of petitions:

--- a/features/admin/moderator_responds_to_petition.feature
+++ b/features/admin/moderator_responds_to_petition.feature
@@ -59,7 +59,7 @@ Feature: Moderator respond to petition
   Scenario: Moderator rejects petition with a suitable reason code
     Given I am logged in as a moderator
     When I look at the next petition on my list
-    And I reject the petition with a reason code "Not the Government/Parliament’s responsibility"
+    And I reject the petition with a reason code "Not the Ministers'/States Assembly's responsibility"
     Then the petition is not available for signing
     But the petition is still available for searching or viewing
 

--- a/features/step_definitions/actioned_steps.rb
+++ b/features/step_definitions/actioned_steps.rb
@@ -21,7 +21,7 @@ Given(/^there (?:are|is) (\d+) petitions? debated in parliament(.+)?$/) do |deba
   end
 end
 
-Given(/^there are (\d+) petitions with a government response$/) do |response_count|
+Given(/^there are (\d+) petitions with a Ministers response$/) do |response_count|
   response_count.times do |count|
     petition = FactoryBot.create(:responded_petition, :action => "Petition #{count}")
   end
@@ -31,7 +31,7 @@ Then(/^I should not see the actioned petitions totals section$/) do
   expect(page).to_not have_css(".actioned-petitions")
 end
 
-Then(/^I should see a total showing (.*?) petitions with a government response$/) do |response_count|
+Then(/^I should see a total showing (.*?) petitions with a Ministers response$/) do |response_count|
   expect(page).to have_css(".actioned-petitions ul li:first-child .count", :text => response_count)
 end
 
@@ -39,10 +39,10 @@ Then(/^I should see a total showing (.*?) petitions debated in parliament$/) do 
   expect(page).to have_css(".actioned-petitions ul li:last-child .count", :text => debated_count)
 end
 
-Then(/^I should see an empty ministers response threshold section$/) do
+Then(/^I should see an empty Ministers response threshold section$/) do
   within(:css, "section[aria-labelledby=response-threshold-heading]") do
     expect(page).to have_no_css("a[href='#{petitions_path(state: :with_response)}']")
-    expect(page).to have_content("The ministers haven’t responded to any petitions yet")
+    expect(page).to have_content("The Ministers haven’t responded to any petitions yet")
   end
 end
 
@@ -55,7 +55,7 @@ end
 
 Then(/^I should see (\d+) petitions counted in the response threshold section$/) do |count|
   within(:css, "section[aria-labelledby=response-threshold-heading]") do
-    link_text = "See all petitions with a response from ministers (#{count})"
+    link_text = "See all petitions with a response from Ministers (#{count})"
     expect(page).to have_link(link_text, href: petitions_path(state: :with_response))
   end
 end

--- a/features/step_definitions/actioned_steps.rb
+++ b/features/step_definitions/actioned_steps.rb
@@ -1,4 +1,4 @@
-Given(/^there (?:are|is) (\d+) petitions? debated in parliament(.+)?$/) do |debated_count, links_command|
+Given(/^there (?:are|is) (\d+) petitions? debated in states assembly(.+)?$/) do |debated_count, links_command|
   video_url, transcript_url, debate_pack_url = nil, nil, nil
 
   if links_command == " with a transcript url"
@@ -35,7 +35,7 @@ Then(/^I should see a total showing (.*?) petitions with a Ministers response$/)
   expect(page).to have_css(".actioned-petitions ul li:first-child .count", :text => response_count)
 end
 
-Then(/^I should see a total showing (.*?) petitions debated in parliament$/) do |debated_count|
+Then(/^I should see a total showing (.*?) petitions debated in states assembly$/) do |debated_count|
   expect(page).to have_css(".actioned-petitions ul li:last-child .count", :text => debated_count)
 end
 

--- a/features/step_definitions/debate_outcome_steps.rb
+++ b/features/step_definitions/debate_outcome_steps.rb
@@ -67,7 +67,7 @@ Then(/^the petition creator should have been emailed about the debate$/) do
   steps %Q(
     Then "#{@petition.creator.email}" should receive an email
     When they open the email
-    Then they should see "Parliament debated your petition" in the email body
+    Then they should see "States Assembly debated your petition" in the email body
     When they follow "#{petition_url(@petition)}" in the email
     Then I should be on the petition page for "#{@petition.action}"
   )
@@ -79,7 +79,7 @@ Then(/^all the signatories of the petition should have been emailed about the de
     steps %Q(
       Then "#{signatory.email}" should receive an email
       When they open the email
-      Then they should see "Parliament debated the petition you signed" in the email body
+      Then they should see "States Assembly debated the petition you signed" in the email body
       When they follow "#{petition_url(@petition)}" in the email
       Then I should be on the petition page for "#{@petition.action}"
     )

--- a/features/step_definitions/debate_scheduled_steps.rb
+++ b/features/step_definitions/debate_scheduled_steps.rb
@@ -3,7 +3,7 @@ Then(/^the petition creator should have been emailed about the scheduled debate$
   steps %Q(
     Then "#{@petition.creator.email}" should receive an email
     When they open the email
-    Then they should see "Parliament is going to debate your petition" in the email body
+    Then they should see "States Assembly is going to debate your petition" in the email body
     When they click the second link in the email
     Then I should be on the petition page for "#{@petition.action}"
   )
@@ -15,7 +15,7 @@ Then(/^all the signatories of the petition should have been emailed about the sc
     steps %Q(
       Then "#{signatory.email}" should receive an email
       When they open the email
-      Then they should see "Parliament is going to debate the petition" in the email body
+      Then they should see "States Assembly is going to debate the petition" in the email body
       When they click the second link in the email
       Then I should be on the petition page for "#{@petition.action}"
     )

--- a/features/step_definitions/moderation_steps.rb
+++ b/features/step_definitions/moderation_steps.rb
@@ -141,7 +141,7 @@ Given(/^a moderator responds to the petition$/) do
     Given I am logged in as a moderator
     And I view all petitions
     And I follow "#{@petition.action}"
-    And I follow "Government response"
+    And I follow "Ministers' response"
     And I fill in "Summary quote" with "Get ready"
     And I fill in "Response in full" with "Parliament here it comes"
     And I press "Email #{NumberHelpers.number_with_delimiter(@petition.signature_count)} petitioners"

--- a/features/step_definitions/petition_steps.rb
+++ b/features/step_definitions/petition_steps.rb
@@ -316,7 +316,7 @@ Given(/^an? (open|closed|rejected) petition "(.*?)" with some (fraudulent)? ?sig
   5.times { FactoryBot.create(:"#{signature_state}_signature", petition: @petition) }
 end
 
-Given(/^the threshold for a parliamentary debate is "(.*?)"$/) do |amount|
+Given(/^the threshold for a states assembly debate is "(.*?)"$/) do |amount|
   Site.instance.update!(threshold_for_debate: amount)
 end
 

--- a/features/step_definitions/petition_steps.rb
+++ b/features/step_definitions/petition_steps.rb
@@ -60,12 +60,12 @@ Given(/^an open petition "(.*?)" with response "(.*?)" and response summary "(.*
   @petition = FactoryBot.create(:responded_petition, action: petition_action, response_details: details, response_summary: summary)
 end
 
-Given(/^a ?(open|closed)? petition "([^"]*)" exists and has received a government response (\d+) days ago$/) do |state, petition_action, parliament_response_days_ago |
+Given(/^a ?(open|closed)? petition "([^"]*)" exists and has received a Ministers response (\d+) days ago$/) do |state, petition_action, parliament_response_days_ago |
   petition_attributes = {
     action: petition_action,
     closed_at: state == 'closed' ? 1.day.ago : 6.months.from_now,
     response_summary: 'Response Summary',
-    response_details: 'Government Response',
+    response_details: "Ministers' Response",
     government_response_at: parliament_response_days_ago.to_i.days.ago
   }
   FactoryBot.create(:responded_petition, petition_attributes)
@@ -229,14 +229,14 @@ When(/^I am allowed to make the petition action too long$/) do
   page.execute_script "document.getElementById('petition_creator_action').removeAttribute('maxlength');"
 end
 
-Then(/^the petition with action: "(.*?)" should have requested a government response email after "(.*?)"$/) do |petition_action, timestamp|
+Then(/^the petition with action: "(.*?)" should have requested a Ministers response email after "(.*?)"$/) do |petition_action, timestamp|
   petition = Petition.find_by!(action: petition_action)
   email_requested_at = petition.get_email_requested_at_for('government_response')
   expect(email_requested_at).to be_present
   expect(email_requested_at).to be >= timestamp.in_time_zone
 end
 
-Then(/^the petition with action: "(.*?)" should not have requested a government response email$/) do |petition_action|
+Then(/^the petition with action: "(.*?)" should not have requested a Ministers response email$/) do |petition_action|
   petition = Petition.find_by!(action: petition_action)
   email_requested_at = petition.get_email_requested_at_for('government_response')
   expect(email_requested_at).to be_nil
@@ -320,7 +320,7 @@ Given(/^the threshold for a parliamentary debate is "(.*?)"$/) do |amount|
   Site.instance.update!(threshold_for_debate: amount)
 end
 
-Given(/^there are (\d+) petitions awaiting a government response$/) do |response_count|
+Given(/^there are (\d+) petitions awaiting a Ministers response$/) do |response_count|
   response_count.times do |count|
     petition = FactoryBot.create(:awaiting_petition, :action => "Petition #{count}")
   end
@@ -338,11 +338,11 @@ Given(/^a petition "(.*?)" exists awaiting debate date$/) do |action|
   @petition = FactoryBot.create(:awaiting_debate_petition, action: action)
 end
 
-Given(/^a petition "(.*?)" exists with government response$/) do |action|
+Given(/^a petition "(.*?)" exists with Ministers response$/) do |action|
   @petition = FactoryBot.create(:responded_petition, action: action)
 end
 
-Given(/^a petition "(.*?)" exists awaiting government response$/) do |action|
+Given(/^a petition "(.*?)" exists awaiting Ministers response$/) do |action|
   @petition = FactoryBot.create(:awaiting_petition, action: action)
 end
 

--- a/features/support/paths.rb
+++ b/features/support/paths.rb
@@ -113,7 +113,7 @@ module NavigationHelpers
     when /^email petitioners form page for "([^\"]*)"$/
       new_admin_petition_email_url(Petition.find_by(action: $1))
 
-    when /^government response page for "([^\"]*)"$/
+    when /^Ministers response page for "([^\"]*)"$/
       admin_petition_government_response_url(Petition.find_by(action: $1))
 
     when /^petition edit details page for "([^\"]*)"$/

--- a/features/suzie_searches_by_free_text.feature
+++ b/features/suzie_searches_by_free_text.feature
@@ -21,8 +21,8 @@ Feature: Suzy Singer searches by free text
     And a petition "Make every monday bank holiday" exists and passed the threshold for a response 10 days ago
 
     # having a govt response
-    Given a petition "Spend more money on defence" exists and has received a government response 10 days ago
-    Given a petition "Save the city foxes" exists and has received a government response 1 days ago
+    Given a petition "Spend more money on defence" exists and has received a Ministers response 10 days ago
+    Given a petition "Save the city foxes" exists and has received a Ministers response 1 days ago
 
     # debated
     Given a petition "Ban Badger Baiting" has been debated 2 days ago
@@ -78,12 +78,12 @@ Feature: Suzy Singer searches by free text
       | The Wombles will rock Glasto | 1 signature          |
 
   Scenario: Search for petitions awaiting a goverment response
-    When I search for "Awaiting government response" with "Monday"
+    When I search for "Awaiting response from Ministers" with "Monday"
     Then I should see the following search results:
       | Make every monday bank holiday | 1 signature |
 
   Scenario: Search for petitions having a goverment response
-    When I search for "Government responses" with "foxes"
+    When I search for "Ministers' responses" with "foxes"
     Then I should see the following search results:
       | Save the city foxes            | 1 signature |
 

--- a/features/suzie_sees_actioned_petitions.feature
+++ b/features/suzie_sees_actioned_petitions.feature
@@ -6,13 +6,13 @@ Feature: Suzie sees actioned petitions
   Scenario: There are no actioned petitions
     Given I am on the home page
     Then I should not see the actioned petitions totals section
-    But I should see an empty ministers response threshold section
+    But I should see an empty Ministers response threshold section
     And I should see an empty debate threshold section
 
-  Scenario: There are petitions with a response from government
-    Given there are 2 petitions with a government response
+  Scenario: There are petitions with a response from Ministers
+    Given there are 2 petitions with a Ministers response
     And I am on the home page
-    Then I should see a total showing 2 petitions with a government response
+    Then I should see a total showing 2 petitions with a Ministers response
     And I should see 2 petitions counted in the response threshold section
     And I should see 2 petitions listed in the response threshold section
     And I should see an empty debate threshold section
@@ -21,15 +21,15 @@ Feature: Suzie sees actioned petitions
     Given there are 3 petitions debated in parliament
     And I am on the home page
     Then I should see a total showing 3 petitions debated in parliament
-    And I should see an empty ministers response threshold section
+    And I should see an empty Ministers response threshold section
     And I should see 3 petitions counted in the debate threshold section
     And I should see 3 petitions listed in the debate threshold section
 
-  Scenario: There are petitions with a response from government and petitions debated in parliament
-    Given there are 5 petitions with a government response
+  Scenario: There are petitions with a response from Ministers and petitions debated in parliament
+    Given there are 5 petitions with a Ministers response
     And there are 2 petitions debated in parliament
     And I am on the home page
-    Then I should see a total showing 5 petitions with a government response
+    Then I should see a total showing 5 petitions with a Ministers response
     And I should see a total showing 2 petitions debated in parliament
     And I should see 5 petitions counted in the response threshold section
     And I should see 3 petitions listed in the response threshold section

--- a/features/suzie_sees_actioned_petitions.feature
+++ b/features/suzie_sees_actioned_petitions.feature
@@ -17,29 +17,29 @@ Feature: Suzie sees actioned petitions
     And I should see 2 petitions listed in the response threshold section
     And I should see an empty debate threshold section
 
-  Scenario: There are petitions debated in parliament
-    Given there are 3 petitions debated in parliament
+  Scenario: There are petitions debated in states assembly
+    Given there are 3 petitions debated in states assembly
     And I am on the home page
-    Then I should see a total showing 3 petitions debated in parliament
+    Then I should see a total showing 3 petitions debated in states assembly
     And I should see an empty Ministers response threshold section
     And I should see 3 petitions counted in the debate threshold section
     And I should see 3 petitions listed in the debate threshold section
 
-  Scenario: There are petitions with a response from Ministers and petitions debated in parliament
+  Scenario: There are petitions with a response from Ministers and petitions debated in states assembly
     Given there are 5 petitions with a Ministers response
-    And there are 2 petitions debated in parliament
+    And there are 2 petitions debated in states assembly
     And I am on the home page
     Then I should see a total showing 5 petitions with a Ministers response
-    And I should see a total showing 2 petitions debated in parliament
+    And I should see a total showing 2 petitions debated in states assembly
     And I should see 5 petitions counted in the response threshold section
     And I should see 3 petitions listed in the response threshold section
     And I should see 2 petitions counted in the debate threshold section
     And I should see 2 petitions listed in the debate threshold section
 
-  Scenario: There are petitions debated in parliament with video, transcript and debate pack urls
-    Given there is 1 petition debated in parliament with a transcript url
-    And there is 1 petition debated in parliament with both video and transcript urls
-    And there is 1 petition debated in parliament with all debate outcome urls
+  Scenario: There are petitions debated in states assembly with video, transcript and debate pack urls
+    Given there is 1 petition debated in states assembly with a transcript url
+    And there is 1 petition debated in states assembly with both video and transcript urls
+    And there is 1 petition debated in states assembly with all debate outcome urls
     And I am on the home page
     Then I should see 2 debated petition video links
     And I should see 3 debated petition transcript links

--- a/features/suzie_unsubscribes_from_petition_updates.feature
+++ b/features/suzie_unsubscribes_from_petition_updates.feature
@@ -7,7 +7,7 @@ Feature: Unsubscribing from petiton updates as Suzie
     Given a petition "Wombles of Wimbledon"
     And the petition "Wombles of Wimbledon" has 5 validated signatures
     And Suzie has already signed the petition
-    And the threshold for a parliamentary debate is "5"
+    And the threshold for a states assembly debate is "5"
     And a moderator responds to the petition
 
   Scenario: Suzie receives an email containing an unsubscription link

--- a/features/suzie_views_a_petition.feature
+++ b/features/suzie_views_a_petition.feature
@@ -93,7 +93,7 @@ Feature: Suzie views a petition
     Given the date is the "01/08/2015"
     And an open petition "Spend more money on Defence" with scheduled debate date of "18/08/2015"
     When I view the petition
-    Then I should see "The States Assembly will debate this petition on 18 August 2015. You'll be able to watch online at parliamentlive.tv"
+    Then I should see "The States Assembly will debate this petition on 18 August 2015. You'll be able to watch online at statesassembly.public-i.tv"
 
   Scenario: Suzie views a petition which will not be debated
     Given a petition "Spend more money on Defence" with a negative debate outcome

--- a/features/suzie_views_all_petitions.feature
+++ b/features/suzie_views_all_petitions.feature
@@ -38,7 +38,7 @@ Feature: Suzy Signer views all petitions
     And a petition "Free the wombles" exists and passed the threshold for a response less than a day ago
     And a petition "Force supermarkets to give unsold food to charities" exists and passed the threshold for a response 1 day ago
     And a petition "Make every monday bank holiday" exists and passed the threshold for a response 10 days ago
-    When I browse to see only "Awaiting government response" petitions
+    When I browse to see only "Awaiting response from Ministers" petitions
     Then I should see "3 petitions"
     And I should see the following ordered list of petitions:
      | Make every monday bank holiday                      |
@@ -47,10 +47,10 @@ Feature: Suzy Signer views all petitions
     And the markup should be valid
 
   Scenario: Suzie browses petitions with a goverment response
-    Given a closed petition "Free the wombles" exists and has received a government response 100 days ago
-    And a petition "Force supermarkets to give unsold food to charities" exists and has received a government response 10 days ago
-    And a petition "Make every monday bank holiday" exists and has received a government response 1 days ago
-    When I browse to see only "Government responses" petitions
+    Given a closed petition "Free the wombles" exists and has received a Ministers response 100 days ago
+    And a petition "Force supermarkets to give unsold food to charities" exists and has received a Ministers response 10 days ago
+    And a petition "Make every monday bank holiday" exists and has received a Ministers response 1 days ago
+    When I browse to see only "Ministers' responses" petitions
     Then I should see "3 petitions"
     And I should see the following ordered list of petitions:
      | Make every monday bank holiday                      |

--- a/spec/controllers/admin/government_response_controller_spec.rb
+++ b/spec/controllers/admin/government_response_controller_spec.rb
@@ -216,10 +216,10 @@ RSpec.describe Admin::GovernmentResponseController, type: :controller, admin: tr
                   ['laura_1@example.com'],
                   ['laura_2@example.com']
                 ])
-                expect(ActionMailer::Base.deliveries[0].subject).to match(/Government responded to “#{petition.action}”/)
-                expect(ActionMailer::Base.deliveries[1].subject).to match(/Government responded to “#{petition.action}”/)
-                expect(ActionMailer::Base.deliveries[2].subject).to match(/Government responded to “#{petition.action}”/)
-                expect(ActionMailer::Base.deliveries[3].subject).to match(/Government responded to “#{petition.action}”/)
+                expect(ActionMailer::Base.deliveries[0].subject).to match(/Ministers responded to “#{petition.action}”/)
+                expect(ActionMailer::Base.deliveries[1].subject).to match(/Ministers responded to “#{petition.action}”/)
+                expect(ActionMailer::Base.deliveries[2].subject).to match(/Ministers responded to “#{petition.action}”/)
+                expect(ActionMailer::Base.deliveries[3].subject).to match(/Ministers responded to “#{petition.action}”/)
               end
             end
           end
@@ -375,7 +375,7 @@ RSpec.describe Admin::GovernmentResponseController, type: :controller, admin: tr
 
           it 'tells the moderator that their changes were saved' do
             do_patch
-            expect(flash[:notice]).to eq 'Updated government response successfully'
+            expect(flash[:notice]).to eq "Updated Ministers' response successfully"
           end
 
           it 'stores the supplied government response in the db' do

--- a/spec/helpers/admin_helper_spec.rb
+++ b/spec/helpers/admin_helper_spec.rb
@@ -78,11 +78,11 @@ RSpec.describe AdminHelper, type: :helper do
     end
 
     it "generates the correct option for 'awaiting_debate_date'" do
-      expect(subject).to have_css("option:nth-of-type(15)[value='awaiting_debate_date']", text: "Awaiting a debate in parliament (15)")
+      expect(subject).to have_css("option:nth-of-type(15)[value='awaiting_debate_date']", text: "Awaiting a debate in States Assembly (15)")
     end
 
     it "generates the correct option for 'with_debate_outcome'" do
-      expect(subject).to have_css("option:nth-of-type(16)[value='with_debate_outcome']", text: "Has been debated in parliament (16)")
+      expect(subject).to have_css("option:nth-of-type(16)[value='with_debate_outcome']", text: "Has been debated in States Assembly (16)")
     end
 
     it "generates the correct option for 'in_debate_queue'" do

--- a/spec/helpers/admin_helper_spec.rb
+++ b/spec/helpers/admin_helper_spec.rb
@@ -70,11 +70,11 @@ RSpec.describe AdminHelper, type: :helper do
     end
 
     it "generates the correct option for 'awaiting_response'" do
-      expect(subject).to have_css("option:nth-of-type(13)[value='awaiting_response']", text: "Awaiting a government response (13)")
+      expect(subject).to have_css("option:nth-of-type(13)[value='awaiting_response']", text: "Awaiting a response from Ministers (13)")
     end
 
     it "generates the correct option for 'with_response'" do
-      expect(subject).to have_css("option:nth-of-type(14)[value='with_response']", text: "With a government response (14)")
+      expect(subject).to have_css("option:nth-of-type(14)[value='with_response']", text: "With a response from Ministers (14)")
     end
 
     it "generates the correct option for 'awaiting_debate_date'" do

--- a/spec/helpers/home_helper_spec.rb
+++ b/spec/helpers/home_helper_spec.rb
@@ -40,26 +40,26 @@ RSpec.describe HomeHelper, type: :helper do
   end
 
   describe "#petition_count" do
-    describe "for counting government responses" do
+    describe "for counting Ministers' responses" do
       it "returns a HTML-safe string" do
         expect(helper.petition_count(:with_response, 1)).to be_an(ActiveSupport::SafeBuffer)
       end
 
       context "when the petition count is 1" do
         it "returns a correctly formatted petition count" do
-          expect(helper.petition_count(:with_response, 1)).to eq("<span class=\"count\">1</span> petition got a response from the ministers")
+          expect(helper.petition_count(:with_response, 1)).to eq("<span class=\"count\">1</span> petition got a response from the Ministers")
         end
       end
 
       context "when the petition count is 100" do
         it "returns a correctly formatted petition count" do
-          expect(helper.petition_count(:with_response, 100)).to eq("<span class=\"count\">100</span> petitions got a response from the ministers")
+          expect(helper.petition_count(:with_response, 100)).to eq("<span class=\"count\">100</span> petitions got a response from the Ministers")
         end
       end
 
       context "when the petition count is 1000" do
         it "returns a correctly formatted petition count" do
-          expect(helper.petition_count(:with_response, 1000)).to eq("<span class=\"count\">1,000</span> petitions got a response from the ministers")
+          expect(helper.petition_count(:with_response, 1000)).to eq("<span class=\"count\">1,000</span> petitions got a response from the Ministers")
         end
       end
     end

--- a/spec/mailers/petition_mailer_spec.rb
+++ b/spec/mailers/petition_mailer_spec.rb
@@ -282,17 +282,17 @@ RSpec.describe PetitionMailer, type: :mailer do
 
       shared_examples_for "a positive debate outcome email" do
         it "has the correct subject" do
-          expect(mail).to have_subject("Parliament debated “Allow organic vegetable vans to use red diesel”")
+          expect(mail).to have_subject("States Assembly debated “Allow organic vegetable vans to use red diesel”")
         end
 
         it "has the positive message in the body" do
-          expect(mail).to have_body_text("Parliament debated your petition")
+          expect(mail).to have_body_text("States Assembly debated your petition")
         end
       end
 
       shared_examples_for "a negative debate outcome email" do
         it "has the correct subject" do
-          expect(mail).to have_subject('Parliament didn’t debate “Allow organic vegetable vans to use red diesel”')
+          expect(mail).to have_subject('States Assembly didn’t debate “Allow organic vegetable vans to use red diesel”')
         end
 
         it "has the negative message in the body" do
@@ -402,17 +402,17 @@ RSpec.describe PetitionMailer, type: :mailer do
 
       shared_examples_for "a positive debate outcome email" do
         it "has the correct subject" do
-          expect(mail).to have_subject("Parliament debated “Allow organic vegetable vans to use red diesel”")
+          expect(mail).to have_subject("States Assembly debated “Allow organic vegetable vans to use red diesel”")
         end
 
         it "has the positive message in the body" do
-          expect(mail).to have_body_text("Parliament debated the petition you signed")
+          expect(mail).to have_body_text("States Assembly debated the petition you signed")
         end
       end
 
       shared_examples_for "a negative debate outcome email" do
         it "has the correct subject" do
-          expect(mail).to have_subject("Parliament didn’t debate “Allow organic vegetable vans to use red diesel”")
+          expect(mail).to have_subject("States Assembly didn’t debate “Allow organic vegetable vans to use red diesel”")
         end
 
         it "has the negative message in the body" do
@@ -523,11 +523,11 @@ RSpec.describe PetitionMailer, type: :mailer do
       it_behaves_like "a debate scheduled email"
 
       it "has the correct subject" do
-        expect(mail).to have_subject("Parliament will debate “Allow organic vegetable vans to use red diesel”")
+        expect(mail).to have_subject("States Assembly will debate “Allow organic vegetable vans to use red diesel”")
       end
 
       it "identifies them as the creator" do
-        expect(mail).to have_body_text(%[Parliament is going to debate your petition])
+        expect(mail).to have_body_text(%[States Assembly is going to debate your petition])
       end
     end
 
@@ -538,11 +538,11 @@ RSpec.describe PetitionMailer, type: :mailer do
       it_behaves_like "a debate scheduled email"
 
       it "has the correct subject" do
-        expect(mail).to have_subject("Parliament will debate “Allow organic vegetable vans to use red diesel”")
+        expect(mail).to have_subject("States Assembly will debate “Allow organic vegetable vans to use red diesel”")
       end
 
       it "identifies them as a ordinary signature" do
-        expect(mail).to have_body_text(%[Parliament is going to debate the petition you signed])
+        expect(mail).to have_body_text(%[States Assembly is going to debate the petition you signed])
       end
     end
   end

--- a/spec/requests/petition_show_spec.rb
+++ b/spec/requests/petition_show_spec.rb
@@ -103,8 +103,8 @@ RSpec.describe "API request to show a petition", type: :request, show_exceptions
 
       expect(attributes).to match(
         a_hash_including(
-          "government_response_at" => a_string_matching(%r[\A\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z\z]),
-          "government_response" => a_hash_including(
+          "ministers_response_at" => a_string_matching(%r[\A\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z\z]),
+          "ministers_response" => a_hash_including(
             "summary" => "Summary of what the government said",
             "details" => "Details of what the government said",
             "created_at" => a_string_matching(%r[\A\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z\z]),

--- a/spec/requests/petitions_list_spec.rb
+++ b/spec/requests/petitions_list_spec.rb
@@ -205,7 +205,7 @@ RSpec.describe "API request to list petitions", type: :request, show_exceptions:
         a_collection_containing_exactly(
           a_hash_including(
             "attributes" => a_hash_including(
-              "government_response" => a_hash_including(
+              "ministers_response" => a_hash_including(
                 "summary" => "Summary of what the government said",
                 "details" => "Details of what the government said"
               )

--- a/spec/routing/admin/petitions/government_response_spec.rb
+++ b/spec/routing/admin/petitions/government_response_spec.rb
@@ -1,27 +1,27 @@
 require 'rails_helper'
 
 RSpec.describe "routes for admin petition government response", type: :routes, admin: true do
-  it "doesn't route GET /admin/petitions/1/government-response/new" do
-    expect(get("/admin/petitions/1/government-response/new")).not_to be_routable
+  it "doesn't route GET /admin/petitions/1/ministers-response/new" do
+    expect(get("/admin/petitions/1/ministers-response/new")).not_to be_routable
   end
 
-  it "doesn't route POST /admin/petitions/1/government-response" do
-    expect(post("/admin/petitions/1/government-response")).not_to be_routable
+  it "doesn't route POST /admin/petitions/1/ministers-response" do
+    expect(post("/admin/petitions/1/ministers-response")).not_to be_routable
   end
 
-  it "routes GET /admin/petitions/1/government-response to admin/government_response#show" do
-    expect(get("/admin/petitions/1/government-response")).to route_to('admin/government_response#show', petition_id: '1')
+  it "routes GET /admin/petitions/1/ministers-response to admin/government_response#show" do
+    expect(get("/admin/petitions/1/ministers-response")).to route_to('admin/government_response#show', petition_id: '1')
   end
 
-  it "doesn't route GET /admin/petitions/1/government-response/edit" do
+  it "doesn't route GET /admin/petitions/1/ministers-response/edit" do
     expect(post("/admin/petitions/1/notes/edit")).not_to be_routable
   end
 
-  it "routes PATCH /admin/petitions/1/government-response to admin/government_response#update" do
-    expect(patch("/admin/petitions/1/government-response")).to route_to('admin/government_response#update', petition_id: '1')
+  it "routes PATCH /admin/petitions/1/ministers-response to admin/government_response#update" do
+    expect(patch("/admin/petitions/1/ministers-response")).to route_to('admin/government_response#update', petition_id: '1')
   end
 
-  it "doesn't route DELETE /admin/petitions/1/government-response" do
-    expect(delete("/admin/petitions/1/government-response")).not_to be_routable
+  it "doesn't route DELETE /admin/petitions/1/ministers-response" do
+    expect(delete("/admin/petitions/1/ministers-response")).not_to be_routable
   end
 end


### PR DESCRIPTION
Rename all references to government to Ministers instead in views, emails and paths.

Also rename all references to parliament to States Assembly instead in views and emails.