### PR TITLE
Resize admin hub logo

### DIFF
--- a/app/assets/stylesheets/petitions/_icons.scss
+++ b/app/assets/stylesheets/petitions/_icons.scss
@@ -136,7 +136,7 @@
   }
 }
 .graphic-states-assembly-large-white {
-  width: 80px;
+  width: 52px;
   height: 64px;
   background-image: image-url("graphics/graphic_states-assembly-white.png");
 

--- a/app/assets/stylesheets/petitions/admin/views/_hub.scss
+++ b/app/assets/stylesheets/petitions/admin/views/_hub.scss
@@ -29,7 +29,7 @@
       .graphic {
         position: absolute;
         top: $gutter-half;
-        right: 0;
+        right: 15px;
       }
     }
   }


### PR DESCRIPTION
Fix for admin logos for retina devices

**Before**
<img width="776" alt="screen shot 2018-06-13 at 11 43 54" src="https://user-images.githubusercontent.com/1370570/41347578-f97b3852-6f01-11e8-98fb-6d26c413985a.png">

**After**
<img width="770" alt="screen shot 2018-06-13 at 11 44 02" src="https://user-images.githubusercontent.com/1370570/41347582-fb82c7f0-6f01-11e8-83e4-bacf3fdb5d7d.png">


