### PR TITLE
Replace references to 'Petitions Committee'

### DIFF
--- a/app/views/petition_mailer/notify_creator_of_debate_outcome.html.erb
+++ b/app/views/petition_mailer/notify_creator_of_debate_outcome.html.erb
@@ -25,15 +25,13 @@
 
 <p>The petition: <%= link_to nil, petition_url(@petition) %></p>
 <% else %>
-<p>The Petitions Committee decided not to debate your petition – “<%= @petition.action %>”</p>
+<p>The Petitions team decided not to debate your petition – “<%= @petition.action %>”</p>
 <% if @debate_outcome.overview? %>
 
 <blockquote><%= auto_link(simple_format(h(@debate_outcome.overview))) %></blockquote>
 <% end %>
 
 <p>The petition: <%= link_to nil, petition_url(@petition) %></p>
-
-<p>Find out more about the Petitions Committee: <%= link_to nil, help_url(anchor: "petitions-committee") %></p>
 <% end %>
 
 <p>Thanks,<br />

--- a/app/views/petition_mailer/notify_creator_of_debate_outcome.text.erb
+++ b/app/views/petition_mailer/notify_creator_of_debate_outcome.text.erb
@@ -26,15 +26,13 @@ Read the research: <%= @debate_outcome.debate_pack_url %>
 The petition: <%= petition_url(@petition) %>
 
 <% else %>
-The Petitions Committee decided not to debate your petition – "<%= @petition.action %>"
+The Petitions team decided not to debate your petition – "<%= @petition.action %>"
 
 <% if @debate_outcome.overview? %>
 <%= @debate_outcome.overview %>
 
 <% end %>
 The petition: <%= petition_url(@petition) %>
-
-Find out more about the Petitions Committee: <%= help_url(anchor: "petitions-committee") %>
 
 <% end %>
 Thanks,

--- a/app/views/petition_mailer/notify_creator_of_threshold_response.html.erb
+++ b/app/views/petition_mailer/notify_creator_of_threshold_response.html.erb
@@ -17,9 +17,9 @@
 <p><%= link_to nil, petition_url(@petition, reveal_response: "yes") %></p>
 
 <% if @petition.signature_count < Site.threshold_for_debate %>
-<p>The Petitions Committee will take a look at this petition and its response. They can press the ministers for action and gather evidence. If this petition reaches <%= Site.formatted_threshold_for_debate %> signatures, the Committee will consider it for a debate.</p>
+<p>The Petitions team will take a look at this petition and its response. They can press the ministers for action and gather evidence. If this petition reaches <%= Site.formatted_threshold_for_debate %> signatures, the team will consider it for a debate.</p>
 <% else %>
-<p>This petition has over <%= Site.formatted_threshold_for_debate %> signatures. The Petitions Committee will consider it for a debate. They can also gather further evidence and press the ministers for action.</p>
+<p>This petition has over <%= Site.formatted_threshold_for_debate %> signatures. The Petitions team will consider it for a debate. They can also gather further evidence and press the ministers for action.</p>
 <% end %>
 
 <p>Thanks,<br />

--- a/app/views/petition_mailer/notify_creator_of_threshold_response.text.erb
+++ b/app/views/petition_mailer/notify_creator_of_threshold_response.text.erb
@@ -17,9 +17,9 @@ Click this link to view the response online:
 <%= petition_url(@petition, reveal_response: "yes") %>
 
 <% if @petition.signature_count < Site.threshold_for_debate %>
-The Petitions Committee will take a look at this petition and its response. They can press the ministers for action and gather evidence. If this petition reaches <%= Site.formatted_threshold_for_debate %> signatures, the Committee will consider it for a debate.
+The Petitions team will take a look at this petition and its response. They can press the ministers for action and gather evidence. If this petition reaches <%= Site.formatted_threshold_for_debate %> signatures, the team will consider it for a debate.
 <% else %>
-This petition has over <%= Site.formatted_threshold_for_debate %> signatures. The Petitions Committee will consider it for a debate. They can also gather further evidence and press the ministers for action.
+This petition has over <%= Site.formatted_threshold_for_debate %> signatures. The Petitions team will consider it for a debate. They can also gather further evidence and press the ministers for action.
 <% end %>
 
 Thanks,

--- a/app/views/petition_mailer/notify_signer_of_debate_outcome.html.erb
+++ b/app/views/petition_mailer/notify_signer_of_debate_outcome.html.erb
@@ -25,15 +25,13 @@
 
 <p>The petition: <%= link_to nil, petition_url(@petition) %></p>
 <% else %>
-<p>The Petitions Committee decided not to debate the petition you signed – “<%= @petition.action %>”</p>
+<p>The Petitions team decided not to debate the petition you signed – “<%= @petition.action %>”</p>
 <% if @debate_outcome.overview? %>
 
 <blockquote><%= auto_link(simple_format(h(@debate_outcome.overview))) %></blockquote>
 <% end %>
 
 <p>The petition: <%= link_to nil, petition_url(@petition) %></p>
-
-<p>Find out more about the Petitions Committee: <%= link_to nil, help_url(anchor: "petitions-committee") %></p>
 <% end %>
 
 <p>Thanks,<br />

--- a/app/views/petition_mailer/notify_signer_of_debate_outcome.text.erb
+++ b/app/views/petition_mailer/notify_signer_of_debate_outcome.text.erb
@@ -26,15 +26,13 @@ Read the research: <%= @debate_outcome.debate_pack_url %>
 The petition: <%= petition_url(@petition) %>
 
 <% else %>
-The Petitions Committee decided not to debate the petition you signed – “<%= @petition.action %>”
+The Petitions team decided not to debate the petition you signed – “<%= @petition.action %>”
 
 <% if @debate_outcome.overview? %>
 <%= @debate_outcome.overview %>
 
 <% end %>
 The petition: <%= petition_url(@petition) %>
-
-Find out more about the Petitions Committee: <%= help_url(anchor: "petitions-committee") %>
 
 <% end %>
 Thanks,

--- a/app/views/petition_mailer/notify_signer_of_threshold_response.html.erb
+++ b/app/views/petition_mailer/notify_signer_of_threshold_response.html.erb
@@ -17,12 +17,10 @@
 <p><%= link_to nil, petition_url(@petition, reveal_response: "yes") %></p>
 
 <% if @petition.signature_count < Site.threshold_for_debate %>
-<p>The Petitions Committee will take a look at this petition and its response. They can press ministers for action and gather evidence. If this petition reaches <%= Site.formatted_threshold_for_debate %> signatures, the Committee will consider it for a debate.</p>
+<p>The Petitions team will take a look at this petition and its response. They can press ministers for action and gather evidence. If this petition reaches <%= Site.formatted_threshold_for_debate %> signatures, the team will consider it for a debate.</p>
 <% else %>
-<p>This petition has over <%= Site.formatted_threshold_for_debate %> signatures. The Petitions Committee will consider it for a debate. They can also gather further evidence and press ministers for action.</p>
+<p>This petition has over <%= Site.formatted_threshold_for_debate %> signatures. The Petitions team will consider it for a debate. They can also gather further evidence and press ministers for action.</p>
 <% end %>
-
-<p>Find out more about the Committee: <%= link_to nil, help_url(anchor: 'petitions-committee') %></p>
 
 <p>Thanks,<br />
 <%= t("petitions.emails.signoff_prefix") %><br />

--- a/app/views/petition_mailer/notify_signer_of_threshold_response.text.erb
+++ b/app/views/petition_mailer/notify_signer_of_threshold_response.text.erb
@@ -17,9 +17,9 @@ Click this link to view the response online:
 <%= petition_url(@petition, reveal_response: "yes") %>
 
 <% if @petition.signature_count < Site.threshold_for_debate %>
-The Petitions Committee will take a look at this petition and its response. They can press the ministers for action and gather evidence. If this petition reaches <%= Site.formatted_threshold_for_debate %> signatures, the Committee will consider it for a debate.
+The Petitions team will take a look at this petition and its response. They can press the ministers for action and gather evidence. If this petition reaches <%= Site.formatted_threshold_for_debate %> signatures, the team will consider it for a debate.
 <% else %>
-This petition has over <%= Site.formatted_threshold_for_debate %> signatures. The Petitions Committee will consider it for a debate. They can also gather further evidence and press the ministers for action.
+This petition has over <%= Site.formatted_threshold_for_debate %> signatures. The Petitions team will consider it for a debate. They can also gather further evidence and press the ministers for action.
 <% end %>
 
 Thanks,

--- a/app/views/petitions/_debate_threshold.html.erb
+++ b/app/views/petitions/_debate_threshold.html.erb
@@ -27,7 +27,7 @@
         <% end -%>
       </section>
     <% else %>
-      <h2 id="debate-threshold-heading">The Petitions Committee decided not to debate this petition</h2>
+      <h2 id="debate-threshold-heading">The Petitions team decided not to debate this petition</h2>
       <% if debate_outcome.overview? -%>
         <%= auto_link(simple_format(h(debate_outcome.overview)), html: { rel: 'nofollow' }) %>
       <% end -%>

--- a/app/views/petitions/create/_replay_petition_stage.html.erb
+++ b/app/views/petitions/create/_replay_petition_stage.html.erb
@@ -23,4 +23,4 @@
 
 <p class="secondary">You can’t change your petition after this point.</p>
 <p class="secondary">If you’ve included personal information, such as details about your health, your family or your job, think carefully about whether you are happy for this to be published.</p>
-<p class="secondary">Published petitions can only be removed from the site with the agreement of the House of Commons Petitions Committee.</p>
+<p class="secondary">Published petitions can only be removed from the site with the agreement of the Petitions team.</p>

--- a/config/locales/petitions.en-GB.yml
+++ b/config/locales/petitions.en-GB.yml
@@ -46,7 +46,7 @@ en-GB:
       awaiting_debate: "Awaiting a debate in the States Assembly (%{quantity})"
 
     list_headers:
-      not_debated: "The Petitions Committee decided not to debate these petitions"
+      not_debated: "The Petitions team decided not to debate these petitions"
 
     facets:
       public:

--- a/features/suzie_views_a_petition.feature
+++ b/features/suzie_views_a_petition.feature
@@ -98,7 +98,7 @@ Feature: Suzie views a petition
   Scenario: Suzie views a petition which will not be debated
     Given a petition "Spend more money on Defence" with a negative debate outcome
     When I view the petition
-    Then I should see "The Petitions Committee decided not to debate this petition"
+    Then I should see "The Petitions team decided not to debate this petition"
 
   Scenario: Suzie views a petition which was debated yesterday
     Given the date is the "27/10/2015"

--- a/spec/mailers/petition_mailer_spec.rb
+++ b/spec/mailers/petition_mailer_spec.rb
@@ -296,7 +296,7 @@ RSpec.describe PetitionMailer, type: :mailer do
         end
 
         it "has the negative message in the body" do
-          expect(mail).to have_body_text("The Petitions Committee decided not to debate your petition")
+          expect(mail).to have_body_text("The Petitions team decided not to debate your petition")
         end
       end
 
@@ -416,7 +416,7 @@ RSpec.describe PetitionMailer, type: :mailer do
         end
 
         it "has the negative message in the body" do
-          expect(mail).to have_body_text("The Petitions Committee decided not to debate the petition you signed")
+          expect(mail).to have_body_text("The Petitions team decided not to debate the petition you signed")
         end
       end
 


### PR DESCRIPTION
'Petitions Committee' -> 'Petitions team'

Also:
  - Remove a couple of redundant links to our help page in petitioner emails