### PR TITLE
Add links to Petitions team in selected emails

### DIFF
--- a/app/views/petition_mailer/notify_creator_of_debate_outcome.html.erb
+++ b/app/views/petition_mailer/notify_creator_of_debate_outcome.html.erb
@@ -32,6 +32,8 @@
 <% end %>
 
 <p>The petition: <%= link_to nil, petition_url(@petition) %></p>
+
+<p>Find out more about the Petitions Team: <%= link_to nil, 'https://beta-statesassembly.gov.je/ABOUT/STATESGREFFE/Pages/default.aspx' %></p>
 <% end %>
 
 <p>Thanks,<br />

--- a/app/views/petition_mailer/notify_creator_of_debate_outcome.text.erb
+++ b/app/views/petition_mailer/notify_creator_of_debate_outcome.text.erb
@@ -34,6 +34,8 @@ The Petitions team decided not to debate your petition – "<%= @petition.action
 <% end %>
 The petition: <%= petition_url(@petition) %>
 
+Find out more about the Petitions Team: https://beta-statesassembly.gov.je/ABOUT/STATESGREFFE/Pages/default.aspx
+
 <% end %>
 Thanks,
 <%= t("petitions.emails.signoff_prefix") %>

--- a/app/views/petition_mailer/notify_creator_of_threshold_response.html.erb
+++ b/app/views/petition_mailer/notify_creator_of_threshold_response.html.erb
@@ -4,9 +4,9 @@
 
 <p>Dear <%= @signature.name %>,</p>
 
-<p>The Government has responded to your petition – “<%= link_to @petition.action, petition_url(@petition) %>”.</p>
+<p>Ministers have responded to your petition – “<%= link_to @petition.action, petition_url(@petition) %>”.</p>
 
-<p>Government responded:</p>
+<p>Ministers responded:</p>
 
 <blockquote><%= auto_link(simple_format(h(@government_response.summary))) %></blockquote>
 
@@ -21,6 +21,8 @@
 <% else %>
 <p>This petition has over <%= Site.formatted_threshold_for_debate %> signatures. The Petitions team will consider it for a debate. They can also gather further evidence and press the ministers for action.</p>
 <% end %>
+
+<p>Find out more about the Petitions Team: <%= link_to nil, 'https://beta-statesassembly.gov.je/ABOUT/STATESGREFFE/Pages/default.aspx' %></p>
 
 <p>Thanks,<br />
 <%= t("petitions.emails.signoff_prefix") %><br />

--- a/app/views/petition_mailer/notify_creator_of_threshold_response.text.erb
+++ b/app/views/petition_mailer/notify_creator_of_threshold_response.text.erb
@@ -22,6 +22,8 @@ The Petitions team will take a look at this petition and its response. They can 
 This petition has over <%= Site.formatted_threshold_for_debate %> signatures. The Petitions team will consider it for a debate. They can also gather further evidence and press the ministers for action.
 <% end %>
 
+Find out more about the Petitions Team: https://beta-statesassembly.gov.je/ABOUT/STATESGREFFE/Pages/default.aspx
+
 Thanks,
 <%= t("petitions.emails.signoff_prefix") %>
 <%= t("petitions.emails.signoff_suffix") %>

--- a/app/views/petition_mailer/notify_signer_of_debate_outcome.html.erb
+++ b/app/views/petition_mailer/notify_signer_of_debate_outcome.html.erb
@@ -34,6 +34,8 @@
 <p>The petition: <%= link_to nil, petition_url(@petition) %></p>
 <% end %>
 
+<p>Find out more about the Petitions Team: <%= link_to nil, 'https://beta-statesassembly.gov.je/ABOUT/STATESGREFFE/Pages/default.aspx' %></p>
+
 <p>Thanks,<br />
 <%= t("petitions.emails.signoff_prefix") %><br />
 <%= t("petitions.emails.signoff_suffix") %></p>

--- a/app/views/petition_mailer/notify_signer_of_debate_outcome.text.erb
+++ b/app/views/petition_mailer/notify_signer_of_debate_outcome.text.erb
@@ -34,6 +34,8 @@ The Petitions team decided not to debate the petition you signed – “<%= @pet
 <% end %>
 The petition: <%= petition_url(@petition) %>
 
+Find out more about the Petitions Team: https://beta-statesassembly.gov.je/ABOUT/STATESGREFFE/Pages/default.aspx
+
 <% end %>
 Thanks,
 <%= t("petitions.emails.signoff_prefix") %>

--- a/app/views/petition_mailer/notify_signer_of_threshold_response.html.erb
+++ b/app/views/petition_mailer/notify_signer_of_threshold_response.html.erb
@@ -22,6 +22,8 @@
 <p>This petition has over <%= Site.formatted_threshold_for_debate %> signatures. The Petitions team will consider it for a debate. They can also gather further evidence and press ministers for action.</p>
 <% end %>
 
+<p>Find out more about the Petitions Team: <%= link_to nil, 'https://beta-statesassembly.gov.je/ABOUT/STATESGREFFE/Pages/default.aspx' %></p>
+
 <p>Thanks,<br />
 <%= t("petitions.emails.signoff_prefix") %><br />
 <%= t("petitions.emails.signoff_suffix") %></p>

--- a/app/views/petition_mailer/notify_signer_of_threshold_response.text.erb
+++ b/app/views/petition_mailer/notify_signer_of_threshold_response.text.erb
@@ -22,6 +22,8 @@ The Petitions team will take a look at this petition and its response. They can 
 This petition has over <%= Site.formatted_threshold_for_debate %> signatures. The Petitions team will consider it for a debate. They can also gather further evidence and press the ministers for action.
 <% end %>
 
+Find out more about the Petitions Team: https://beta-statesassembly.gov.je/ABOUT/STATESGREFFE/Pages/default.aspx
+
 Thanks,
 <%= t("petitions.emails.signoff_prefix") %>
 <%= t("petitions.emails.signoff_suffix") %>


### PR DESCRIPTION
Added links to HTML and text versions of emails for the Jersey Petitions Team. Previews of HTML versions below:

Notify signer when decision is not to debate:
![screencapture-localhost-3000-rails-mailers-petition_mailer-not_debated_petition_signer_notification-2018-07-05-10_55_29](https://user-images.githubusercontent.com/1370570/42317669-cffdb514-8044-11e8-8caf-372207987ff6.png)
Notify creator when decision is not to debate:
![screencapture-localhost-3000-rails-mailers-petition_mailer-not_debated_petition_creator_notification-2018-07-05-10_56_03](https://user-images.githubusercontent.com/1370570/42317676-d339bcc8-8044-11e8-81a6-0c86b8afb407.png)
Notify signer of debate: 
![screencapture-localhost-3000-rails-mailers-petition_mailer-notify_signer_of_threshold_response-2018-07-05-11_06_56](https://user-images.githubusercontent.com/1370570/42317682-d6ed52b2-8044-11e8-9e56-2860f7663b67.png)
Notify creator of debate:
![screencapture-localhost-3000-rails-mailers-petition_mailer-notify_creator_of_threshold_response-2018-07-05-11_03_38](https://user-images.githubusercontent.com/1370570/42317679-d5a1f4d0-8044-11e8-96ed-155adadb2f3e.png)
