### PR TITLE
Auto-link URLs that are sent in the feedback form

### DIFF
--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -2,4 +2,8 @@ class Feedback < ActiveRecord::Base
   validates :comment, presence: true, length: { maximum: 32768 }
   validates :petition_link_or_title, length: { maximum: 255 }, allow_blank: true
   validates :email, format: { with: EMAIL_REGEX }, length: { maximum: 255 }, allow_blank: true
+
+  def petition_link?
+    petition_link_or_title =~ /\A#{Regexp.escape(Site.url)}/
+  end
 end

--- a/app/views/feedback_mailer/send_feedback.html.erb
+++ b/app/views/feedback_mailer/send_feedback.html.erb
@@ -4,8 +4,12 @@
 <hr>
 
 <p>
-  <strong>Link:</strong><br>
-  <%= @feedback.petition_link_or_title %>
+  <strong>Link or title:</strong><br>
+  <% if @feedback.petition_link? %>
+    <%= link_to nil, @feedback.petition_link_or_title %>
+  <% else %>
+    <%= @feedback.petition_link_or_title %>
+  <% end %>
 </p>
 
 <p>

--- a/app/views/feedback_mailer/send_feedback.text.erb
+++ b/app/views/feedback_mailer/send_feedback.text.erb
@@ -3,7 +3,7 @@ Comments:
 
 =======================================================================
 
-Link:
+Link or title:
 <%= @feedback.petition_link_or_title %>
 
 Email:


### PR DESCRIPTION
Ensures that it's only URLs to the Petitions website that are auto-linked for security concerns.