### PR TITLE
Don't show signatures by parish on rejected petitions

### DIFF
--- a/app/views/petitions/_petition.json.jbuilder
+++ b/app/views/petitions/_petition.json.jbuilder
@@ -63,7 +63,7 @@ json.attributes do
     json.debate nil
   end
 
-  if petition_page?
+  if petition_page? && petition.published?
     json.signatures_by_parish petition.signatures_by_parish do |parish|
       json.name parish.name
       json.signature_count parish.signature_count

--- a/spec/requests/petition_show_spec.rb
+++ b/spec/requests/petition_show_spec.rb
@@ -200,5 +200,20 @@ RSpec.describe "API request to show a petition", type: :request, show_exceptions
         )
       )
     end
+
+    it "doesn't include the signatures by parish data in rejected petitions" do
+      petition = FactoryBot.create :rejected_petition
+
+      FactoryBot.create :parish, :st_saviour, id: 1
+      FactoryBot.create :parish, :st_clement, id: 2
+
+      FactoryBot.create :parish_petition_journal, parish_id: 1, signature_count: 123, petition: petition
+      FactoryBot.create :parish_petition_journal, parish_id: 2, signature_count: 456, petition: petition
+
+      get "/petitions/#{petition.id}.json"
+      expect(response).to be_success
+
+      expect(attributes.keys).not_to include("signatures_by_parish")
+    end
   end
 end


### PR DESCRIPTION
Rejected petitions only have creator and sponsor signatures.