### PR TITLE
Ignore webrick CVE-2026-38969

### DIFF
--- a/.bundler-audit.yml
+++ b/.bundler-audit.yml
@@ -1,0 +1,2 @@
+ignore:
+  - GHSA-h4w6-wx8r-p68v


### PR DESCRIPTION
We only use webrick when running features/specs.